### PR TITLE
Add possibility to add an overrides file.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,28 +108,21 @@ mariadb_mysql_port: 3306
 mariadb_mysql_root_password: 'root'
 
 mariadb_mysql_settings:
-  collation_server: 'latin1_swedish_ci'
-  character_set_client: 'latin1'
   datadir: /var/lib/mysql
   expire_logs_days: 10
-  # ON|OFF
-  innodb_buffer_pool_size: 128M
-  innodb_doublewrite: 'ON'
-  innodb_flush_log_at_timeout: 1
-  innodb_read_io_threads: 4
-  innodb_write_io_threads: 4
-  join_buffer_size: 1M
   #Default is 16M
   key_buffer_size: '{{ (ansible_memtotal_mb | int * mariadb_mysql_mem_multiplier) | round | int }}M'
   max_allowed_packet: 16M
   max_binlog_size: 100M
-  max_connections: 150
-  max_heap_table_size: 16M
   query_cache_limit: 1M
   query_cache_size: 16M
   thread_cache_size: 8
   thread_stack: 192K
-  tmp_table_size: 16M
+
+# If this is defined it will create a file with overrides
+# mariadb_config_overrides:
+#   mariadb:
+#     max_connections: 2048
 
 # Define additional MySQL users
 mariadb_mysql_users: []

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -51,6 +51,13 @@
     state: "present"
   become: true
 
+- name: redhat | add an overrides file
+  template:
+    src: "etc/mariadb_overrides.cnf.j2"
+    dest: "/etc/my.cnf.d/overrides.cnf"
+  become: true
+  when: mariadb_config_overrides is defined
+
 - name: debian | installing mariadb-galera packages
   apt:
     name: "{{ item }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -22,6 +22,26 @@
   when: >
         ansible_distribution != "Fedora"
 
+- name: Precreate /etc/my.cnf.d in case we need to add mariadb_config_overrides file
+  file:
+    path: /etc/my.cnf.d
+    state: directory
+    mode: 0755
+    recurse: yes
+  become: true
+  changed_when: false
+  when: mariadb_config_overrides is defined
+
+- name: redhat | add an overrides file
+  template:
+    src: "etc/mariadb_overrides.cnf.j2"
+    dest: "/etc/my.cnf.d/overrides.cnf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  become: true
+  when: mariadb_config_overrides is defined
+
 - name: redhat | installing mariadb mysql
   yum:
     name: "{{ item }}"
@@ -44,6 +64,17 @@
     - 'MySQL-python'
   when: >
         ansible_distribution == "Fedora"
+
+- name: Remove migrated-from-my.cnf-settings.conf that is causing MariaDB to not start
+  file:
+    path: /etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
+    state: absent
+  become: true
+
+- name: reload systemd for MariaDB changes
+  become: true
+  systemd:
+    daemon_reload: true
 
 - name: redhat | ensuring mariadb mysql is enabled on boot and started
   service:

--- a/templates/etc/mariadb_overrides.cnf.j2
+++ b/templates/etc/mariadb_overrides.cnf.j2
@@ -1,0 +1,9 @@
+
+{% for group, settings in mariadb_config_overrides.items() %}
+
+[{{ group }}]
+{% for key, value in settings.items() %}
+{{ key }} = {{ value }}
+{% endfor %}
+
+{% endfor %}


### PR DESCRIPTION
Closes #27 and #29.

As an extra I've removed unused elements from mariadb_mysql_settings... so they don't create confusion.