### PR TITLE
Ubuntu 20.04 updates

### DIFF
--- a/Vagrant/bootstrap.yml
+++ b/Vagrant/bootstrap.yml
@@ -18,13 +18,12 @@
 
     - name: installing ansible pre-reqs (Debian)
       apt:
-        name: "{{ item }}"
+        name:
+          - libffi-dev
+          - libssl-dev
+          - python-dev
+          - python-setuptools
         state: present
-      with_items:
-        - libffi-dev
-        - libssl-dev
-        - python-dev
-        - python-setuptools
       when: >
             ansible_os_family == "Debian"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,11 @@ galera_allow_root_from_any: false
 # Define bind address for galera cluster
 galera_cluster_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + galera_cluster_bind_interface]['ipv4']['address'] }}"
 
+# bind address for MariaDB's 3306 port.
+# By default takes the value of the galera cluster IP, but can be overriden
+# to 0.0.0.0 (for example) to allow MySQL connections to localhost
+mariadb_bind_address: "{{ galera_cluster_bind_address }}"
+
 # Define interface in which to bind
 # ex. eth0|eth1|enp0s3|enp0s8
 galera_cluster_bind_interface: "enp0s8"
@@ -119,13 +124,22 @@ mariadb_mysql_settings:
   max_binlog_size: 100M
   query_cache_limit: 1M
   query_cache_size: 16M
-  thread_cache_size: 8
+  # MariaDB default: https://mariadb.com/kb/en/server-system-variables/#thread_cache_size
+  thread_cache_size: 256
   thread_stack: 192K
 
 # If this is defined it will create a file with overrides
 # mariadb_config_overrides:
 #   mariadb:
 #     max_connections: 2048
+
+# Create these MariaDB databases during installation
+# Example:
+# mariadb_databases:
+#   - name: keystone
+#   - name: mydb
+#     init_script: files/init_mydb.sql
+mariadb_databases: []
 
 # Define additional MySQL users
 mariadb_mysql_users: []
@@ -149,3 +163,59 @@ mariadb_smtp_domain_name: "{{ mariadb_pri_domain_name }}"
 
 # Define smtp server to send email through
 mariadb_smtp_server: "smtp.{{ mariadb_pri_domain_name }}"
+
+# Character sets. MariaDB's default: latin1
+mariadb_charset_server: utf8mb4
+mariadb_collation_server: utf8mb4_general_ci
+mariadb_charset_client: utf8mb4
+
+# What percentage of system memory to use for InnoDB row cache
+mariadb_innodb_mem_multiplier: 0.50
+
+# Only used internally
+mariadb_one_gig_bytes: "{{ 1024 * 1024 * 1024 }}"
+
+# Amount of memory to use for InnoDB row cache.
+# Overrides "mariadb_innodb_mem_multiplier" setting.
+# If you don't set this in bytes (so MB or GB), the pool instances calculation
+# below will fail
+mariadb_innodb_buffer_pool_size: >-
+  {{ (ansible_memtotal_mb|int * mariadb_innodb_mem_multiplier * 1024 * 1024)
+  | round | int }}
+
+# https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_instances
+mariadb_innodb_buffer_pool_instances: >-
+  {% if mariadb_innodb_buffer_pool_size|int > mariadb_one_gig_bytes %}{{
+  (mariadb_innodb_buffer_pool_size|int / mariadb_one_gig_bytes) | abs | int
+  }}{% else %}1{% endif %}
+
+# Maximum allowed concurrent connections. MySQL default is 151
+mariadb_max_connections: auto
+
+# Queries that take more time than 'mariadb_long_query_time' to complete are
+# considered as slow. Values in seconds or 'auto' for the MySQL default (10)
+mariadb_long_query_time: auto
+
+# Enable logging of slow queries
+mariadb_slow_query_log_enabled: false
+
+# The calculation below only counts real CPU cores, not SMT ones which MariaDB
+# rightfully does not like.
+mariadb_real_cpus: "{{ ansible_processor_count * ansible_processor_cores }}"
+
+# MariaDB default: 4
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_read_io_threads
+mariadb_innodb_read_io_threads: >-
+  {% if mariadb_real_cpus|int > 8
+  %}{{ mariadb_real_cpus|int / 2 | abs | int }}{%
+  else %}4{% endif %}
+
+# MariaDB default: 4
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_write_io_threads
+mariadb_innodb_write_io_threads: >-
+  {% if mariadb_real_cpus|int > 8
+  %}{{ mariadb_real_cpus|int / 2 | abs | int }}{%
+  else %}4{% endif %}
+
+# https://mariadb.com/kb/en/mariadb-memory-allocation/#swappiness
+mariadb_swappiness: "1"

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -7,6 +7,7 @@
     password: "{{ mariadb_mysql_root_password }}"
   become: true
   run_once: true
+  no_log: true
   with_items:
     - "{{ ansible_hostname }}"
     - "127.0.0.1"
@@ -21,6 +22,7 @@
     group: "root"
     mode: "u=rw,g=,o="
   become: true
+  no_log: true
   when: ansible_os_family == "RedHat"
 
 - name: configure_root_access | updating root passwords
@@ -30,6 +32,7 @@
     name: root
     password: "{{ mariadb_mysql_root_password }}"
   become: true
+  no_log: true
   with_items:
     - "{{ ansible_hostname }}"
     - "127.0.0.1"
@@ -44,6 +47,7 @@
     password: "{{ mariadb_mysql_root_password }}"
     priv: "*.*:ALL,GRANT"
   become: true
+  no_log: true
   with_items:
     - "%"
   when: galera_allow_root_from_any|bool

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,7 +12,7 @@
     name:
       - "apt-transport-https"
       - "software-properties-common"
-      - "python-mysqldb"
+      - "python3-pymysql"
       - "rsync"
     state: "present"
   become: true
@@ -25,9 +25,11 @@
     state: "present"
   become: true
   when: >
+    galera_enable_mariadb_repo|bool and (
     ansible_distribution == "Debian" or
     (ansible_distribution == "Ubuntu" and
     ansible_distribution_version <= '14.04')
+    )
 
 - name: debian | Adding MariaDB Repo Keys
   apt_key:
@@ -36,6 +38,7 @@
     state: "present"
   become: true
   when:
+    - galera_enable_mariadb_repo|bool
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_version is version('16.04', '>=')
 
@@ -53,7 +56,7 @@
   become: true
   when: galera_enable_mariadb_repo|bool
 
-- name: redhat | add an overrides file
+- name: debian | add an overrides file
   template:
     src: "etc/mariadb_overrides.cnf.j2"
     dest: "/etc/my.cnf.d/overrides.cnf"
@@ -66,7 +69,6 @@
       - "mariadb-server"
     state: "present"
   become: true
-  when: galera_enable_mariadb_repo|bool
 
 - name: debian | configuring root my.cnf
   template:
@@ -75,6 +77,7 @@
     owner: "root"
     group: "root"
     mode: "u=rw,g=,o="
+  no_log: true
   become: true
 
 - name: debian | adding debian-sys-maintenance permissions to mysql
@@ -84,4 +87,5 @@
     state: "present"
     password: "{{ galera_deb_db_password }}"
     login_unix_socket: "{{ mariadb_login_unix_socket }}"
+  no_log: true
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,25 @@
     ansible_service_mgr == "systemd" and
     mariadb_oom_score_adjust != 0
 
+# Borrowed from percona xtradb cluster ansible role:
+# https://github.com/cdelgehier/ansible-role-XtraDB-Cluster/blob/master/tasks/bootstrap.yml
+# Many thanks to Cedric DELGEHIER
+- name: Configure swappiness
+  sysctl:
+    name: vm.swappiness
+    value: "{{ mariadb_swappiness }}"
+    state: present
+  become: true
+  when:
+    - "not (
+      (ansible_virtualization_role == 'guest')
+      and (ansible_virtualization_type == 'lxc')
+      )"
+
 - include: setup_cluster.yml
+
+- include: mysql_databases.yml
+  when: mariadb_databases | count > 0
 
 - include: mysql_users.yml
   tags: mysql-users

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,13 +12,12 @@
 
 - name: redhat | installing pre-reqs
   yum:
-    name: "{{ item }}"
+    name:
+      - "MySQL-python"
+      - "socat"
     state: "present"
     update_cache: yes
   become: true
-  with_items:
-    - "MySQL-python"
-    - "socat"
   when: >
     ansible_distribution != "Fedora"
 
@@ -44,24 +43,22 @@
 
 - name: redhat | installing mariadb mysql
   yum:
-    name: "{{ item }}"
+    name:
+      - "MariaDB-server"
+      - "galera"
     state: "present"
   become: true
-  with_items:
-    - "MariaDB-server"
-    - "galera"
   when: >
     ansible_distribution != "Fedora"
 
 - name: redhat | installing mariadb mysql
   dnf:
-    name: "{{ item }}"
+    name:
+      - "MariaDB-server"
+      - "galera"
+      - "MySQL-python"
     state: present
   become: true
-  with_items:
-    - "MariaDB-server"
-    - "galera"
-    - "MySQL-python"
   when: >
     ansible_distribution == "Fedora"
 

--- a/templates/etc/my.cnf.d/reset.server.cnf.j2
+++ b/templates/etc/my.cnf.d/reset.server.cnf.j2
@@ -26,7 +26,7 @@
 #
 # Allow server to accept connections on all interfaces.
 #
-#bind-address={{ galera_cluster_bind_address }}
+#bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -11,6 +11,32 @@
 # this is only for the mysqld standalone daemon
 [mysqld]
 
+character-set-server  = {{ mariadb_charset_server }}
+collation-server      = {{ mariadb_collation_server }}
+init-connect          = 'SET NAMES {{ mariadb_charset_server }}'
+
+{% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
+innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
+{% endif %}
+{% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
+innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
+{% endif %}
+{% if mariadb_innodb_write_io_threads | default('auto') != "auto" %}
+innodb_write_io_threads = {{ mariadb_innodb_write_io_threads }}
+{% endif %}
+{% if mariadb_max_connections | default('auto') != "auto" %}
+max_connections = {{ mariadb_max_connections }}
+{% endif %}
+{% if mariadb_slow_query_log_enabled %}
+slow_query_log
+{% endif %}
+{% if mariadb_long_query_time | default('auto') != "auto" %}
+long_query_time = {{ mariadb_long_query_time }}
+{% endif %}
+
 #
 # * Galera-related settings
 #
@@ -26,7 +52,7 @@ innodb_autoinc_lock_mode=2
 #
 # Allow server to accept connections on all interfaces.
 #
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/templates/etc/my.cnf.d/temp.server.cnf.j2
+++ b/templates/etc/my.cnf.d/temp.server.cnf.j2
@@ -26,7 +26,7 @@ innodb_autoinc_lock_mode=2
 #
 # Allow server to accept connections on all interfaces.
 #
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/templates/etc/mysql/conf.d/client.cnf.j2
+++ b/templates/etc/mysql/conf.d/client.cnf.j2
@@ -1,2 +1,2 @@
 [client]
-default-character-set		= utf8
+default-character-set		= {{ mariadb_charset_client }}

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -5,7 +5,7 @@ default-storage-engine=innodb
 innodb_autoinc_lock_mode=2
 query_cache_size=0
 query_cache_type=0
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 
 [galera]
 wsrep_on=ON

--- a/templates/etc/mysql/conf.d/temp.galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/temp.galera.cnf.j2
@@ -5,7 +5,7 @@ default-storage-engine=innodb
 innodb_autoinc_lock_mode=2
 query_cache_size=0
 query_cache_type=0
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 
 [galera]
 wsrep_on=ON

--- a/templates/etc/mysql/debian.cnf.j2
+++ b/templates/etc/mysql/debian.cnf.j2
@@ -4,10 +4,10 @@
 host     = localhost
 user     = debian-sys-maint
 password = {{ galera_deb_db_password }}
-socket   = "{{ mariadb_login_unix_socket }}
+socket   = {{ mariadb_login_unix_socket }}
 [mysql_upgrade]
 host     = localhost
 user     = debian-sys-maint
 password = {{ galera_deb_db_password }}
-socket   = "{{ mariadb_login_unix_socket }}
+socket   = {{ mariadb_login_unix_socket }}
 basedir  = /usr

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -12,7 +12,7 @@ socket = {{ mariadb_login_unix_socket }}
 basedir = /usr
 datadir	= {{ mariadb_mysql_settings['datadir'] }}
 expire_logs_days = {{ mariadb_mysql_settings['expire_logs_days'] }}
-key_buffer = {{ mariadb_mysql_settings['key_buffer_size'] }}
+key_buffer_size = {{ mariadb_mysql_settings['key_buffer_size'] }}
 lc-messages-dir = /usr/share/mysql
 log_error = /var/log/mysql/error.log
 max_allowed_packet = {{ mariadb_mysql_settings['max_allowed_packet'] }}
@@ -24,10 +24,36 @@ query_cache_limit = {{ mariadb_mysql_settings['query_cache_limit'] }}
 query_cache_size = {{ mariadb_mysql_settings['query_cache_size'] }}
 skip-external-locking
 socket = {{ mariadb_login_unix_socket }}
-thread_cache_size = {{ mariadb_mysql_settings['query_cache_size'] }}
+thread_cache_size = {{ mariadb_mysql_settings['thread_cache_size'] }}
 thread_stack = {{ mariadb_mysql_settings['thread_stack'] }}
 tmpdir = /tmp
 user = mysql
+
+character-set-server  = {{ mariadb_charset_server }}
+collation-server      = {{ mariadb_collation_server }}
+init-connect          = 'SET NAMES {{ mariadb_charset_server }}'
+
+{% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
+innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
+{% endif %}
+{% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
+innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
+{% endif %}
+{% if mariadb_innodb_write_io_threads | default('auto') != "auto" %}
+innodb_write_io_threads = {{ mariadb_innodb_write_io_threads }}
+{% endif %}
+{% if mariadb_max_connections | default('auto') != "auto" %}
+max_connections = {{ mariadb_max_connections }}
+{% endif %}
+{% if mariadb_slow_query_log_enabled %}
+slow_query_log
+{% endif %}
+{% if mariadb_long_query_time | default('auto') != "auto" %}
+long_query_time = {{ mariadb_long_query_time }}
+{% endif %}
 
 [mysqldump]
 max_allowed_packet = 16M
@@ -35,8 +61,9 @@ quick
 quote-names
 
 [mysql]
+default-character-set		= {{ mariadb_charset_client }}
 
 [isamchk]
-key_buffer = 16M
+key_buffer_size = 16M
 
 !includedir /etc/mysql/conf.d/


### PR DESCRIPTION
- Allow MySQL service to bind to 0.0.0.0 by introducing new variable
  "mariadb_bind_address". This was needed because consul connect needs
  access to 127.0.0.1, but the existing role binds to the NIC interface
  only.
- Support setting up server and client character sets and collations
  with new variables: "mariadb_charset_client", "mariadb_charset_server"
  and "mariadb_collation_server"
- Support setting up InnoDB memory, IO threads and slow query settings.
- Support setting host swappiness to MariaDB recommended values
- Support databases creation
- Renamed deprecated "key_buffer" setting to recommended
"key_buffer_size".
- Removed stray quotes from debian maintainer user configuration
template.
- Fixed mistyped "thread_cache_size" value in Debian configuration
  template.
- Fixed mariadb not getting installed when "galera_enable_mariadb_repo"
  was set to "false"
- Improved redhat package installation by using package lists instead of
  running apt in a loop.
- Debian systems install python3-pymysql to use mysql commands instead
  of python-mysqldb which is deprecated in Ubuntu 20.04
- No longer add the MariaDB repo in Debian systems when
  "galera_enable_mariadb_repo" is set to false.
- Added "no_log: true" to all tasks that handle passwords to avoid them
  leaking into log files.