### PR TITLE
Allow the overriding of MariaDB's bind address.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,11 @@ galera_allow_root_from_any: false
 # Define bind address for galera cluster
 galera_cluster_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + galera_cluster_bind_interface]['ipv4']['address'] }}"
 
+# bind address for MariaDB's 3306 port.
+# By default takes the value of the galera cluster IP, but can be overriden
+# to 0.0.0.0 (for example) to allow MySQL connections to localhost
+mariadb_bind_address: "{{ galera_cluster_bind_address }}"
+
 # Define interface in which to bind
 # ex. eth0|eth1|enp0s3|enp0s8
 galera_cluster_bind_interface: "enp0s8"

--- a/templates/etc/my.cnf.d/reset.server.cnf.j2
+++ b/templates/etc/my.cnf.d/reset.server.cnf.j2
@@ -26,7 +26,7 @@
 #
 # Allow server to accept connections on all interfaces.
 #
-#bind-address={{ galera_cluster_bind_address }}
+#bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -26,7 +26,7 @@ innodb_autoinc_lock_mode=2
 #
 # Allow server to accept connections on all interfaces.
 #
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/templates/etc/my.cnf.d/temp.server.cnf.j2
+++ b/templates/etc/my.cnf.d/temp.server.cnf.j2
@@ -26,7 +26,7 @@ innodb_autoinc_lock_mode=2
 #
 # Allow server to accept connections on all interfaces.
 #
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
 #wsrep_slave_threads=1

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -5,7 +5,7 @@ default-storage-engine=innodb
 innodb_autoinc_lock_mode=2
 query_cache_size=0
 query_cache_type=0
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 
 [galera]
 wsrep_on=ON

--- a/templates/etc/mysql/conf.d/temp.galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/temp.galera.cnf.j2
@@ -5,7 +5,7 @@ default-storage-engine=innodb
 innodb_autoinc_lock_mode=2
 query_cache_size=0
 query_cache_type=0
-bind-address={{ galera_cluster_bind_address }}
+bind-address={{ mariadb_bind_address }}
 
 [galera]
 wsrep_on=ON


### PR DESCRIPTION
Until now the role would automatically select the IP address of the
interface specified in the "galera_cluster_bind_interface" and use
both the galera cluster and MariaDB to bind to it.

This is fine for the galera part, but it results in MariaDB _not_
listening to 127.0.0.1. This was needed in my case because consul
connect only uses 127.0.0.1.

This change separates this behaviour by introducing the variable
"mariadb_bind_address". By default it takes the value of
"galera_cluster_bind_address" so no functionality changed. But you can
now override just "mariadb_bind_address" and set it to 0.0.0.0 for
example if you need normal MySQL clients to connect without interfering
with how galera operates.