### PR TITLE
Fixed looped package installation

### DIFF
--- a/Vagrant/bootstrap.yml
+++ b/Vagrant/bootstrap.yml
@@ -18,13 +18,12 @@
 
     - name: installing ansible pre-reqs (Debian)
       apt:
-        name: "{{ item }}"
+        name:
+          - libffi-dev
+          - libssl-dev
+          - python-dev
+          - python-setuptools
         state: present
-      with_items:
-        - libffi-dev
-        - libssl-dev
-        - python-dev
-        - python-setuptools
       when: >
             ansible_os_family == "Debian"
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,13 +12,12 @@
 
 - name: redhat | installing pre-reqs
   yum:
-    name: "{{ item }}"
+    name:
+      - "MySQL-python"
+      - "socat"
     state: "present"
     update_cache: yes
   become: true
-  with_items:
-    - "MySQL-python"
-    - "socat"
   when: >
     ansible_distribution != "Fedora"
 
@@ -44,24 +43,22 @@
 
 - name: redhat | installing mariadb mysql
   yum:
-    name: "{{ item }}"
+    name:
+      - "MariaDB-server"
+      - "galera"
     state: "present"
   become: true
-  with_items:
-    - "MariaDB-server"
-    - "galera"
   when: >
     ansible_distribution != "Fedora"
 
 - name: redhat | installing mariadb mysql
   dnf:
-    name: "{{ item }}"
+    name:
+      - "MariaDB-server"
+      - "galera"
+      - "MySQL-python"
     state: present
   become: true
-  with_items:
-    - "MariaDB-server"
-    - "galera"
-    - "MySQL-python"
   when: >
     ansible_distribution == "Fedora"
 


### PR DESCRIPTION
Providing the list of packages to install directly is now the
recommended way. In addition, this speeds up deployment because the
package manager is called only once for all packages instead of once
per package.