### PR TITLE
Fix installing mainline debian packages

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -25,9 +25,11 @@
     state: "present"
   become: true
   when: >
+    galera_enable_mariadb_repo|bool and (
     ansible_distribution == "Debian" or
     (ansible_distribution == "Ubuntu" and
     ansible_distribution_version <= '14.04')
+    )
 
 - name: debian | Adding MariaDB Repo Keys
   apt_key:
@@ -36,6 +38,7 @@
     state: "present"
   become: true
   when:
+    - galera_enable_mariadb_repo|bool
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_version is version('16.04', '>=')
 
@@ -53,7 +56,7 @@
   become: true
   when: galera_enable_mariadb_repo|bool
 
-- name: redhat | add an overrides file
+- name: debian | add an overrides file
   template:
     src: "etc/mariadb_overrides.cnf.j2"
     dest: "/etc/my.cnf.d/overrides.cnf"
@@ -66,7 +69,6 @@
       - "mariadb-server"
     state: "present"
   become: true
-  when: galera_enable_mariadb_repo|bool
 
 - name: debian | configuring root my.cnf
   template:


### PR DESCRIPTION
- Don't add MariaDB repo if galera_enable_mariadb_repo is false
- Install mariadb-server package regardless, it's named the same in the
  mainline Ubuntu repos.
- Fixed a small description typo