### PR TITLE
Allow setting charsets, InnoDB and I/O tuning, etc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -149,3 +149,92 @@ mariadb_smtp_domain_name: "{{ mariadb_pri_domain_name }}"
 
 # Define smtp server to send email through
 mariadb_smtp_server: "smtp.{{ mariadb_pri_domain_name }}"
+
+# Character sets.
+# MariaDB's defaults: latin1
+
+# Role default: unset (server defaults)
+mariadb_charset_server: auto
+mariadb_collation_server: auto
+# Role default: utf8
+mariadb_charset_client: utf8
+
+# Recommended utf8 settings:
+# https://mariadb.com/kb/en/setting-character-sets-and-collations/#example-changing-the-default-character-set-to-utf-8
+# mariadb_charset_server: utf8mb4
+# mariadb_collation_server: utf8mb4_general_ci
+# mariadb_charset_client: utf8mb4
+
+# InnoDB tuning
+
+# Amount of memory to use for InnoDB row cache.
+# Set to a specific amount in bytes or to "auto" for server defaults.
+mariadb_innodb_buffer_pool_size: auto
+
+# How many pool instances to use for the buffer pool
+# Each instance should ideally be at least 1GB in size.
+# Set to "auto" for server defaults
+# https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_instances
+mariadb_innodb_buffer_pool_instances: auto
+
+# Automatic pool size tuning example:
+
+# What percentage of system memory to use for InnoDB row cache
+# 0.5 means 50%
+mariadb_innodb_mem_multiplier: 0.5
+
+# Calculate the amount of memory based on the above percentage, in bytes
+# mariadb_innodb_buffer_pool_size: >-
+#   {{ (ansible_memtotal_mb|int * mariadb_innodb_mem_multiplier * 1024 * 1024)
+#   | round | int }}
+
+# Bytes in a gigabyte. Only used internally to calculate the number of
+# pool instances in "mariadb_innodb_buffer_pool_instances"
+mariadb_one_gig_bytes: "{{ 1024 * 1024 * 1024 }}"
+
+# Calculate the amount of instances so that they are about 1G in size
+# mariadb_innodb_buffer_pool_instances: >-
+#   {% if mariadb_innodb_buffer_pool_size|int > mariadb_one_gig_bytes|int %}{{
+#   (mariadb_innodb_buffer_pool_size|int / mariadb_one_gig_bytes|int) |abs |int
+#   }}{% else %}1{% endif %}
+
+# Maximum allowed concurrent connections. MySQL default is 151
+mariadb_max_connections: auto
+
+# Queries that take more time than 'mariadb_long_query_time' to complete are
+# considered as slow. Values in seconds or 'auto' for the MySQL default (10)
+# phpmyadmin recommends this value to be set to "5" or less.
+mariadb_long_query_time: auto
+
+# Enable logging of slow queries
+mariadb_slow_query_log_enabled: false
+
+# MariaDB default: 4
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_read_io_threads
+mariadb_innodb_read_io_threads: auto
+
+# MariaDB default: 4
+# https://mariadb.com/kb/en/innodb-system-variables/#innodb_write_io_threads
+mariadb_innodb_write_io_threads: auto
+
+# Automatic I/O thread tuning for systems with more than 8 CPU cores
+
+# The calculation below only counts real CPU cores, not SMT ones which MariaDB
+# rightfully does not like.
+mariadb_real_cpus: "{{ ansible_processor_count * ansible_processor_cores }}"
+
+# mariadb_innodb_read_io_threads: >-
+#   {% if mariadb_real_cpus|int > 8
+#   %}{{ mariadb_real_cpus|int / 2 | abs | int }}{%
+#   else %}4{% endif %}
+
+# mariadb_innodb_write_io_threads: >-
+#   {% if mariadb_real_cpus|int > 8
+#   %}{{ mariadb_real_cpus|int / 2 | abs | int }}{%
+#   else %}4{% endif %}
+
+# Tune system swappiness. Default value "auto" means don't tune.
+# Recommended value based on:
+# https://mariadb.com/kb/en/mariadb-memory-allocation/#swappiness
+# mariadb_swappiness: 1
+mariadb_swappiness: auto

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,22 @@
     ansible_service_mgr == "systemd" and
     mariadb_oom_score_adjust != 0
 
+# Borrowed from percona xtradb cluster ansible role:
+# https://github.com/cdelgehier/ansible-role-XtraDB-Cluster/blob/master/tasks/bootstrap.yml
+# Many thanks to Cedric DELGEHIER
+- name: Configure swappiness
+  sysctl:
+    name: vm.swappiness
+    value: "{{ mariadb_swappiness }}"
+    state: present
+  become: true
+  when:
+    - mariadb_swappiness != 'auto'
+    - "not (
+      (ansible_virtualization_role == 'guest')
+      and (ansible_virtualization_type == 'lxc')
+      )"
+
 - include: setup_cluster.yml
 
 - include: mysql_users.yml

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -11,6 +11,36 @@
 # this is only for the mysqld standalone daemon
 [mysqld]
 
+{% if mariadb_charset_server | default('auto') != 'auto' %}
+character-set-server  = {{ mariadb_charset_server }}
+init-connect          = 'SET NAMES {{ mariadb_charset_server }}'
+{% endif %}
+{% if mariadb_collation_server | default('auto') != 'auto' %}
+collation-server      = {{ mariadb_collation_server }}
+{% endif %}
+
+{% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
+innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
+{% endif %}
+{% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
+innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
+{% endif %}
+{% if mariadb_innodb_write_io_threads | default('auto') != "auto" %}
+innodb_write_io_threads = {{ mariadb_innodb_write_io_threads }}
+{% endif %}
+{% if mariadb_max_connections | default('auto') != "auto" %}
+max_connections = {{ mariadb_max_connections }}
+{% endif %}
+{% if mariadb_slow_query_log_enabled %}
+slow_query_log
+{% endif %}
+{% if mariadb_long_query_time | default('auto') != "auto" %}
+long_query_time = {{ mariadb_long_query_time }}
+{% endif %}
+
 #
 # * Galera-related settings
 #

--- a/templates/etc/mysql/conf.d/client.cnf.j2
+++ b/templates/etc/mysql/conf.d/client.cnf.j2
@@ -1,2 +1,2 @@
 [client]
-default-character-set		= utf8
+default-character-set		= {{ mariadb_charset_client }}

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -29,12 +29,43 @@ thread_stack = {{ mariadb_mysql_settings['thread_stack'] }}
 tmpdir = /tmp
 user = mysql
 
+{% if mariadb_charset_server | default('auto') != 'auto' %}
+character-set-server  = {{ mariadb_charset_server }}
+init-connect          = 'SET NAMES {{ mariadb_charset_server }}'
+{% endif %}
+{% if mariadb_collation_server | default('auto') != 'auto' %}
+collation-server      = {{ mariadb_collation_server }}
+{% endif %}
+
+{% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
+innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
+{% endif %}
+{% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
+innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
+{% endif %}
+{% if mariadb_innodb_write_io_threads | default('auto') != "auto" %}
+innodb_write_io_threads = {{ mariadb_innodb_write_io_threads }}
+{% endif %}
+{% if mariadb_max_connections | default('auto') != "auto" %}
+max_connections = {{ mariadb_max_connections }}
+{% endif %}
+{% if mariadb_slow_query_log_enabled %}
+slow_query_log
+{% endif %}
+{% if mariadb_long_query_time | default('auto') != "auto" %}
+long_query_time = {{ mariadb_long_query_time }}
+{% endif %}
+
 [mysqldump]
 max_allowed_packet = 16M
 quick
 quote-names
 
 [mysql]
+default-character-set		= {{ mariadb_charset_client }}
 
 [isamchk]
 key_buffer = 16M


### PR DESCRIPTION
Allow setting of:
- client and server character sets
- InnoDB buffer pool size and number of instances. Includes auto-tuning
  example based on available system memory
- Read and write I/O thread amount. Includes auto-tuning example for
  systems with more than 8 CPU cores.
- maximum server connections
- system swappiness
- slow query timeout
- logging of slow queries

All of the above settings are set to "auto" by default, which means
"use server defaults", so that they are compatible with any existing
clusters deployed using earlier versions of this role.