### PR TITLE
Change thread_cache_size to MariaDB default (256)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,7 +119,8 @@ mariadb_mysql_settings:
   max_binlog_size: 100M
   query_cache_limit: 1M
   query_cache_size: 16M
-  thread_cache_size: 8
+  # MariaDB default: https://mariadb.com/kb/en/server-system-variables/#thread_cache_size
+  thread_cache_size: 256
   thread_stack: 192K
 
 # If this is defined it will create a file with overrides


### PR DESCRIPTION
See:
https://mariadb.com/kb/en/server-system-variables/#thread_cache_size