### PR TITLE
Ensure specified NIC name exists in target system

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,15 @@
 # tasks file for ansible-mariadb-galera-cluster
 - include: set_facts.yml
 
+- name: Ensure NIC specified in 'galera_cluster_bind_interface' exists
+  assert:
+    that:
+      - galera_cluster_bind_interface in ansible_interfaces
+    fail_msg: >-
+      The NIC name '{{ galera_cluster_bind_interface }}' specified in
+      'galera_cluster_bind_interface' does not exist on the target host.
+      Available interfaces are: {{ ansible_interfaces | join(',') }}.
+
 - include: unconfigure_cluster.yml
   when: >
     galera_reconfigure_galera is defined and


### PR DESCRIPTION
If the variable "galera_cluster_bind_interface" is set to a
non-existent interface name, the role fails while creating the
galera "gcomm://" string with a cryptic "AnsibleUndefined is None"
error message. This assertion here ensures this never happens.

I spent about an hour troubleshooting why the gcomm string failed
during development so I hope with this nobody else needs to.