### PR TITLE
Add more Galera notify SMTP settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -258,6 +258,10 @@ galera_notify_mail_to: "{{ galera_email_notifications }}"
 
 # Define smtp server to send notifications through
 galera_notify_smtp_server: "{{ mariadb_smtp_server }}"
+galera_notify_smtp_auth: "False"
+galera_notify_smtp_username: ""
+galera_notify_smtp_password: ""
+galera_notify_smtp_port: 25
 
 # Defines if cacti monitoring should be enabled for mysql - If used. May remove later.
 galera_enable_cacti_monitoring: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,7 @@ mariadb_charset_server: "auto"
 mariadb_collation_server: "auto"
 # Role default: utf8
 mariadb_charset_client: "utf8"
-  
+
 # If this is defined it will create a file with overrides
 # mariadb_config_overrides:
 #   mariadb:

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -32,16 +32,16 @@ THIS_SERVER = socket.gethostname()
 
 # Server hostname or IP address
 mariadb_smtp_server = '{{ galera_notify_smtp_server }}'
-SMTP_PORT = 25
+SMTP_PORT = {{ galera_notify_smtp_port }}
 
 # Set to True if you need SMTP over SSL
 SMTP_SSL = False
 
 # Set to True if you need to authenticate to your SMTP server
-SMTP_AUTH = False
+SMTP_AUTH = {{ galera_notify_smtp_auth }}
 # Fill in authorization information here if True above
-SMTP_USERNAME = ''
-SMTP_PASSWORD = ''
+SMTP_USERNAME = '{{ galera_notify_smtp_username }}'
+SMTP_PASSWORD = '{{ galera_notify_smtp_password }}'
 
 # Takes a single sender
 MAIL_FROM = '{{ galera_notify_mail_from }}'


### PR DESCRIPTION
Adds SMTP variables for the `galeranotify.py` script, to allow easier customization.