### PR TITLE
Add ability to configure systemd timeout start sec

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -133,6 +133,9 @@ mariadb_oom_score_adjust: 0
 # notice for SystemD: 0 does not mean 'unlimited', use 'infinity' for unlimited
 mariadb_max_open_files: 0
 
+# Add the posibility to adjust timeout for starting service (only works for SystemD)
+mariadb_timeout_start_sec: 0
+
 # InnoDB tuning
 
 # Amount of memory to use for InnoDB row cache.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ click==7.1.2              # via click-completion, click-help-colors, cookiecutte
 colorama==0.4.4           # via rich
 commonmark==0.9.1         # via rich
 cookiecutter==1.7.2       # via molecule
-cryptography==3.3.1       # via ansible-base, paramiko
+cryptography==3.3.2       # via ansible-base, paramiko
 distro==1.5.0             # via selinux
 docker==4.4.1             # via -r requirements.in, molecule-docker
 enrich==1.2.6             # via molecule

--- a/tasks/system_performance_tuning.yml
+++ b/tasks/system_performance_tuning.yml
@@ -9,6 +9,11 @@
     ansible_service_mgr == "systemd" and
     mariadb_oom_score_adjust != 0
 
+- include: timeout-start-sec.yml
+  when: >
+    ansible_service_mgr == "systemd" and
+    mariadb_timeout_start_sec != 0
+
 # Borrowed from percona xtradb cluster ansible role:
 # https://github.com/cdelgehier/ansible-role-XtraDB-Cluster/blob/master/tasks/bootstrap.yml
 # Many thanks to Cedric DELGEHIER

--- a/tasks/timeout-start-sec.yml
+++ b/tasks/timeout-start-sec.yml
@@ -1,0 +1,22 @@
+---
+# Supplementary configuration file
+- name: timeout-start-sec | Create folder
+  file:
+    path: "/etc/systemd/system/mariadb.service.d"
+    state: "directory"
+    recurse: true
+    owner: "root"
+    group: "root"
+    mode: "u=rwx,g=rx,o=rx"
+  notify: "reload systemd daemon"
+  become: true
+
+- name: timeout-start-sec | Add the overriding file
+  template:
+    src: "etc/systemd/system/mariadb.service.d/timeout-start-sec.conf.j2"
+    dest: "/etc/systemd/system/mariadb.service.d/timeout-start-sec.conf"
+    owner: "root"
+    group: "root"
+    mode: "u=rw,g=r,o=r"
+  notify: "reload systemd daemon"
+  become: true

--- a/templates/etc/systemd/system/mariadb.service.d/timeout-start-sec.conf.j2
+++ b/templates/etc/systemd/system/mariadb.service.d/timeout-start-sec.conf.j2
@@ -1,0 +1,5 @@
+
+[Service]
+# Override defualt timeout for starting service, due to long SST duration
+TimeoutStartSec={{ mariadb_timeout_start_sec }}
+


### PR DESCRIPTION
This solves one feature from list mentioned in https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/issues/37