### PR TITLE
TLS encryption for mysql, wsrep and sst

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -138,6 +138,10 @@ galera_ist_recv_addr_port: "{{ galera_wsrep_node_address_port|int + 1 }}"
 # NAT or in similar cases where the public and private addresses differ.
 galera_ist_recv_bind: "{{ galera_cluster_bind_address }}"
 
+# This option enables configuration TLS encryption for WSREP (disabled by default).
+# To enable encryption mariadb_tls_files must be configured also.
+galera_wsrep_tls_enabled: false
+
 # MariaDB system tunning
 
 # Tune system swappiness. Default value "auto" means don't tune.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,6 +142,28 @@ galera_ist_recv_bind: "{{ galera_cluster_bind_address }}"
 # To enable encryption mariadb_tls_files must be configured also.
 galera_wsrep_tls_enabled: false
 
+# This option enables configuration TLS encryption for SST (disabled by default).
+# To enable encryption mariadb_tls_files must be configured also.
+galera_sst_tls_enabled: false
+
+# If you enable galera_sst_tls_enabled mariabackup need to authenticate locally on donor node.
+# Credentials bellow are appended to other user defined mariadb_mysql_users.
+# By default unix_socket auth plugin is used, for more info see documentaion
+# https://mariadb.com/kb/en/mariabackup-sst-method/#passwordless-authentication-unix-socket.
+# In MariaDB 10.4.3 and later unix_socket is instaleld by default, for later version see
+# https://mariadb.com/kb/en/authentication-plugin-unix-socket.
+# If you need to use password auth change set maruadb_sst_user.plugin to mysql_native_password
+# and set mariadb_sst_password.
+mariadb_sst_username: "mysql"
+mariadb_sst_password: ""
+mariadb_sst_user:
+  - name: "{{ mariadb_sst_username }}"
+    hosts:
+      - "localhost"
+    plugin: "unix_socket"
+    password: "{{ mariadb_sst_password }}"
+    priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
+
 # MariaDB system tunning
 
 # Tune system swappiness. Default value "auto" means don't tune.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,27 @@ mariadb_mysql_settings:
   thread_cache_size: 256
   thread_stack: "192K"
 
+# Define TLS certs & keys which will be used to encrypt mysql, WSREP, SST connections
+# This variable should have defined exactly three items, any other item count is handled like none.
+# Items must be named ca_cert, server_key, server_cert.  Each item must have defined values name and content. 
+# Names will be used to create such file at target system. Content can be defined inline like example below, 
+# or can by linked to variables defined in ansible-vault or other lookup plugins (file, hashicorp vault, etc.)
+#
+# mariadb_tls_files:
+#   ca_cert:
+#     name: "ca.pem"
+#     content: |
+#       -- ca-cert content --
+#   server_key:
+#     name: "server-key.pem"
+#     content: |
+#       -- server-cert content --
+#   server_cert:
+#     name: "server-cert.pem"
+#     content: |
+#       -- server-cert content --
+mariadb_tls_files: []
+
 # Recommended utf8 settings:
 # https://mariadb.com/kb/en/setting-character-sets-and-collations/#example-changing-the-default-character-set-to-utf-8
 # mariadb_charset_server: utf8mb4

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -70,6 +70,6 @@
 
 - name: debian | installing mariadb-galera packages
   apt:
-    name: "{{ mariadb_packages }}"
+    name: "{{ galera_sst_tls_enabled | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
     state: "present"
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: gather os specific variables
   include_vars: "{{ item }}"
   tags:
+    - always
     - install
     - config
   with_first_found:
@@ -41,6 +42,11 @@
     - install
     - config
 
+- import_tasks: mysql_users.yml
+  tags:
+    - config
+    - mysql_users
+
 - import_tasks: setup_cluster.yml
   tags:
     - config
@@ -53,11 +59,6 @@
   tags:
     - mysql_databases
   when: mariadb_databases | count > 0
-
-- import_tasks: mysql_users.yml
-  tags:
-    - mysql_users
-  when: mariadb_mysql_users is defined
 
 - import_tasks: galera_monitoring.yml
   tags:

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -17,5 +17,5 @@
   delegate_to: "{{ galera_mysql_first_node }}"
   run_once: true
   with_subelements:
-    - "{{ mariadb_mysql_users }}"
+    - "{{ galera_sst_tls_enabled | ternary( mariadb_mysql_users | union( mariadb_sst_user ), mariadb_mysql_users ) }}"
     - "hosts"

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -6,7 +6,10 @@
     host: "{{ item.1 }}"
     login_unix_socket: "{{ mariadb_login_unix_socket }}"
     name: "{{ item.0.name }}"
-    password: "{{ item.0.password }}"
+    password: "{{ item.0.password | default(omit) }}"
+    plugin: "{{ item.0.plugin | default(omit) }}"
+    plugin_auth_string: "{{ item.0.plugin_auth_string | default(omit) }}"
+    plugin_hash_string: "{{ item.0.plugin_hash_string | default(omit) }}"
     priv: "{{ item.0.priv | default('*.*:USAGE') }}"
     state: "{{ item.0.state | default('present') }}"
   become: true

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -11,6 +11,8 @@
     state: "{{ item.0.state | default('present') }}"
   become: true
   no_log: true
+  delegate_to: "{{ galera_mysql_first_node }}"
+  run_once: true
   with_subelements:
     - "{{ mariadb_mysql_users }}"
-    - hosts
+    - "hosts"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -57,7 +57,7 @@
 
 - name: redhat | installing mariadb mysql
   yum:
-    name: "{{ mariadb_packages }}"
+    name: "{{ galera_sst_tls_enabled | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
     state: "present"
     update_cache: true
   become: true

--- a/tasks/setup_cluster.yml
+++ b/tasks/setup_cluster.yml
@@ -13,6 +13,33 @@
   register: "galera_cluster_configured"
 
 # Configure common settings for mariadb and galera
+- name: setup_cluster | create TLS certificates directory
+  file:
+    path: "{{ mariadb_certificates_dir }}"
+    state: "directory"
+    owner: "mysql"
+    group: "mysql"
+    mode: '0500'
+  become: true
+  when:
+    - mariadb_tls_files
+    - mariadb_tls_files | length == 3
+
+- name: setup_cluster | copy TLS CA cert, server cert & private key
+  copy:
+    content: "{{ item.value.content }}"
+    dest: "{{ mariadb_certificates_dir }}/{{ item.value.name }}"
+    owner: "mysql"
+    group: "mysql"
+    mode: '0400'
+    backup: true
+  with_dict: "{{ mariadb_tls_files }}"
+  become: true
+  no_log: true
+  when:
+    - mariadb_tls_files
+    - mariadb_tls_files | length == 3
+
 - name: setup_cluster | configuring settings for mariadb and galera
   template:
     src: "{{ item }}.j2"

--- a/tasks/setup_cluster.yml
+++ b/tasks/setup_cluster.yml
@@ -172,6 +172,7 @@
     name: "{{ mariadb_systemd_service_name }}"
     state: "started"
   become: true
+  throttle: 1
   register: "_mariadb_galera_cluster_joined"
   until: _mariadb_galera_cluster_joined.status.ActiveState == "active"
   retries: 60
@@ -236,5 +237,3 @@
   when: >
     _mariadb_galera_cluster_reconfigured.changed or
     _mariadb_galera_cluster_node_restarted.changed
-
-

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -80,9 +80,21 @@ bind-address={{ mariadb_bind_address }}
 #wsrep_slave_threads=1
 #innodb_flush_log_at_trx_commit=0
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+{% else %}
 wsrep_sst_method=rsync
+{% endif %}
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
+{% endif %}
+
+[sst]
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+encrypt=3
+tcert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+tkey = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}
 
 # this is only for embedded server

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -63,6 +63,11 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made
 #wsrep_cluster_address="gcomm://"
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_wsrep_tls_enabled %}
+# WSREP TLS encryption settings
+wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
+{% endif %}
+
 binlog_format=row
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -41,6 +41,12 @@ slow_query_log
 long_query_time = {{ mariadb_long_query_time }}
 {% endif %}
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 %}
+ssl_ca = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}
+ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
+{% endif %}
+
 #
 # * Galera-related settings
 #

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -80,9 +80,21 @@ bind-address={{ mariadb_bind_address }}
 #wsrep_slave_threads=1
 #innodb_flush_log_at_trx_commit=0
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+{% else %}
 wsrep_sst_method=rsync
+{% endif %}
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
+{% endif %}
+
+[sst]
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+encrypt=3
+tcert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+tkey = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}
 
 # this is only for embedded server

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -63,6 +63,11 @@ wsrep_cluster_name="{{ galera_cluster_name }}"
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made
 wsrep_cluster_address="gcomm://"
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_wsrep_tls_enabled %}
+# WSREP TLS encryption settings
+wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
+{% endif %}
+
 binlog_format=row
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -41,6 +41,12 @@ slow_query_log
 long_query_time = {{ mariadb_long_query_time }}
 {% endif %}
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 %}
+ssl_ca = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}
+ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
+{% endif %}
+
 #
 # * Galera-related settings
 #

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -20,6 +20,11 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made
 #wsrep_cluster_address="gcomm://"
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_wsrep_tls_enabled %}
+# WSREP TLS encryption settings
+wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
+{% endif %}
+
 wsrep_sst_method=rsync
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -25,7 +25,13 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+{% else %}
 wsrep_sst_method=rsync
+{% endif %}
+
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
@@ -37,4 +43,11 @@ wsrep_node_address="{{ galera_wsrep_node_address }}"
 
 {% if galera_extra_wsrep_provider_options is defined %}
 wsrep_provider_options = "{% for item in galera_extra_wsrep_provider_options %}{% set _key = item.split(': ')[0] %}{% set _val = galera_extra_wsrep_provider_options[_key] %}{{ _key }} = {{ _val }}{% if not loop.last %}; {% endif %}{% endfor %}"
+{% endif %}
+
+[sst]
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+encrypt=3
+tcert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+tkey = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -20,6 +20,11 @@ wsrep_cluster_name="{{ galera_cluster_name }}"
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made
 wsrep_cluster_address="gcomm://"
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_wsrep_tls_enabled %}
+# WSREP TLS encryption settings
+wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
+{% endif %}
+
 wsrep_sst_method=rsync
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -25,7 +25,13 @@ wsrep_cluster_address="gcomm://"
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+wsrep_sst_method=mariabackup
+wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+{% else %}
 wsrep_sst_method=rsync
+{% endif %}
+
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
@@ -37,4 +43,11 @@ wsrep_node_address="{{ galera_wsrep_node_address }}"
 
 {% if galera_extra_wsrep_provider_options is defined %}
 wsrep_provider_options = "{% for item in galera_extra_wsrep_provider_options %}{% set _key = item.split(': ')[0] %}{% set _val = galera_extra_wsrep_provider_options[_key] %}{{ _key }} = {{ _val }}{% if not loop.last %}; {% endif %}{% endfor %}"
+{% endif %}
+
+[sst]
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
+encrypt=3
+tcert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+tkey = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -59,6 +59,12 @@ slow_query_log
 long_query_time = {{ mariadb_long_query_time }}
 {% endif %}
 
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 %}
+ssl_ca = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}
+ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
+{% endif %}
+
 [mysqldump]
 max_allowed_packet = 16M
 quick

--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -6,6 +6,8 @@ mariadb_packages:
   - "python3-mysql"
   - "MariaDB-server"
   - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
 mariadb_systemd_service_name: "mariadb"
 mariadb_confs:

--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -6,6 +6,7 @@ mariadb_packages:
   - "python3-mysql"
   - "MariaDB-server"
   - "galera-4"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
 mariadb_systemd_service_name: "mariadb"
 mariadb_confs:
   - "etc/my.cnf.d/server.cnf"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -9,6 +9,8 @@ mariadb_pre_req_packages:
 mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
 mariadb_packages:
   - "mariadb-server"
+mariabackup_packages:
+  - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -9,6 +9,7 @@ mariadb_pre_req_packages:
 mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
 mariadb_packages:
   - "mariadb-server"
+mariadb_certificates_dir: "/etc/mysql/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:
   - "etc/mysql/debian.cnf"

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -5,6 +5,8 @@ mariadb_packages:
   - "python3-mysql"
   - "MariaDB-server"
   - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
 mariadb_systemd_service_name: "mariadb"
 mariadb_confs:

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -5,6 +5,7 @@ mariadb_packages:
   - "python3-mysql"
   - "MariaDB-server"
   - "galera-4"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
 mariadb_systemd_service_name: "mariadb"
 mariadb_confs:
   - "etc/my.cnf.d/server.cnf"

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -5,6 +5,7 @@ mariadb_pre_req_packages:
 mariadb_packages:
   - "MariaDB-server"
   - "galera-4"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:
   - "etc/my.cnf.d/server.cnf"

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -5,6 +5,8 @@ mariadb_pre_req_packages:
 mariadb_packages:
   - "MariaDB-server"
   - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -8,6 +8,8 @@ mariadb_pre_req_packages:
 mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
 mariadb_packages:
   - "mariadb-server"
+mariabackup_packages:
+  - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -8,6 +8,7 @@ mariadb_pre_req_packages:
 mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
 mariadb_packages:
   - "mariadb-server"
+mariadb_certificates_dir: "/etc/mysql/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:
   - "etc/mysql/debian.cnf"


### PR DESCRIPTION
Solves https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/issues/37
- added option to use TLS for MySQL connections
- added option to use TLS for WSREP connections
- added option to configure MySQL authentication plugins for users
- added condition to append mariadb_sst_user to user-defined mariadb_users
- moved tasks for user creation before setup_cluster tasks, because the user
  must exist before other nodes joins the cluster
- added option to configure TLS for SST connections
- bugfix for failures when joining the cluster, make it serial