### PR TITLE
Add mariadb backup as optional option for wsrep_sst_method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+.idea/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,7 +166,7 @@ mariadb_sst_user:
 # This option defines the wsrep_sst_method that should be used by the cluster.
 # Possible options:
 #  - mariabackup - recommended for MariaDB - default if TLS is enabled via galera_sst_tls_enabled,
-#  - xtrabackup-v2 - there are limitations, please see https://mariadb.com/kb/en/xtrabackup-v2-sst-method/
+#  - xtrabackup-v2 - not recommended, not implemented by this role, see limitations at https://mariadb.com/kb/en/xtrabackup-v2-sst-method/
 #  - rsync - default
 galera_sst_method: "{{ (mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled) | ternary('mariabackup', 'rsync') }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -165,10 +165,10 @@ mariadb_sst_user:
 
 # This option defines the wsrep_sst_method that should be used by the cluster.
 # Possible options:
-#  - mariabackup (recommended for MariaDB),
-#  - xtrabackup-v2 (there are limitations, please see https://mariadb.com/kb/en/xtrabackup-v2-sst-method/)
-#  - rsync
-galera_sst_method: rsync
+#  - mariabackup - recommended for MariaDB - default if TLS is enabled via galera_sst_tls_enabled,
+#  - xtrabackup-v2 - there are limitations, please see https://mariadb.com/kb/en/xtrabackup-v2-sst-method/
+#  - rsync - default
+galera_sst_method: "{{ (mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled) | ternary('mariabackup', 'rsync') }}"
 
 # MariaDB system tunning
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,8 +114,7 @@ galera_cluster_name: "vagrant-test"
 galera_cluster_nodes_group: "galera-cluster-nodes"
 
 # https://mariadb.com/kb/en/mariadb/wsrep_provider_options/
-galera_extra_wsrep_provider_options:
-  []
+galera_extra_wsrep_provider_options: []
   # evs.auto_evict: 1
   # evs.delayed_margin: 'PT5S'
   # evs.delayed_keep_period: 'PT45S'
@@ -163,6 +162,13 @@ mariadb_sst_user:
     plugin: "unix_socket"
     password: "{{ mariadb_sst_password }}"
     priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
+
+# This option defines the wsrep_sst_method that should be used by the cluster.
+# Possible options:
+#  - mariabackup (recommended for MariaDB),
+#  - xtrabackup-v2 (there are limitations, please see https://mariadb.com/kb/en/xtrabackup-v2-sst-method/)
+#  - rsync
+galera_sst_method: rsync
 
 # MariaDB system tunning
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -70,6 +70,6 @@
 
 - name: debian | installing mariadb-galera packages
   apt:
-    name: "{{ galera_sst_tls_enabled | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
+    name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
     state: "present"
   become: true

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -17,5 +17,5 @@
   delegate_to: "{{ galera_mysql_first_node }}"
   run_once: true
   with_subelements:
-    - "{{ ternary( mariadb_mysql_users | union( mariadb_sst_user ), mariadb_mysql_users ) if (galera_sst_method == 'mariabackup') else mariadb_mysql_users }}"
+    - "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_mysql_users | union( mariadb_sst_user ), mariadb_mysql_users ) }}"
     - "hosts"

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -17,5 +17,5 @@
   delegate_to: "{{ galera_mysql_first_node }}"
   run_once: true
   with_subelements:
-    - "{{ galera_sst_tls_enabled | ternary( mariadb_mysql_users | union( mariadb_sst_user ), mariadb_mysql_users ) }}"
+    - "{{ ternary( mariadb_mysql_users | union( mariadb_sst_user ), mariadb_mysql_users ) if (galera_sst_method == 'mariabackup') else mariadb_mysql_users }}"
     - "hosts"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -57,7 +57,7 @@
 
 - name: redhat | installing mariadb mysql
   yum:
-    name: "{{ galera_sst_tls_enabled | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
+    name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
     state: "present"
     update_cache: true
   become: true

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -68,6 +68,11 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+wsrep_sst_method={{ galera_sst_method }}
+{% if galera_sst_method == 'mariabackup' %}
+wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
+{% endif %}
+
 binlog_format=row
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
@@ -80,12 +85,6 @@ bind-address={{ mariadb_bind_address }}
 #wsrep_slave_threads=1
 #innodb_flush_log_at_trx_commit=0
 
-{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
-wsrep_sst_method=mariabackup
-wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
-{% else %}
-wsrep_sst_method=rsync
-{% endif %}
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -68,6 +68,11 @@ wsrep_cluster_address="gcomm://"
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+wsrep_sst_method={{ galera_sst_method }}
+{% if galera_sst_method == 'mariabackup' %}
+wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
+{% endif %}
+
 binlog_format=row
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
@@ -80,12 +85,6 @@ bind-address={{ mariadb_bind_address }}
 #wsrep_slave_threads=1
 #innodb_flush_log_at_trx_commit=0
 
-{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
-wsrep_sst_method=mariabackup
-wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
-{% else %}
-wsrep_sst_method=rsync
-{% endif %}
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -25,11 +25,9 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
-{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
-wsrep_sst_method=mariabackup
+wsrep_sst_method={{ galera_sst_method }}
+{% if galera_sst_method == 'mariabackup' %}
 wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
-{% else %}
-wsrep_sst_method=rsync
 {% endif %}
 
 {% if galera_enable_galera_monitoring_script %}

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -25,11 +25,9 @@ wsrep_cluster_address="gcomm://"
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
-{% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
-wsrep_sst_method=mariabackup
+wsrep_sst_method={{ galera_sst_method }}
+{% if galera_sst_method == 'mariabackup' %}
 wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
-{% else %}
-wsrep_sst_method=rsync
 {% endif %}
 
 {% if galera_enable_galera_monitoring_script %}


### PR DESCRIPTION
mariabackup is an alternative to rsync that does not block the donor node