### PR TITLE
Bugfix for WSREP SST auth config typo

### DIFF
--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -82,7 +82,7 @@ bind-address={{ mariadb_bind_address }}
 
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
 wsrep_sst_method=mariabackup
-wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% else %}
 wsrep_sst_method=rsync
 {% endif %}

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -82,7 +82,7 @@ bind-address={{ mariadb_bind_address }}
 
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
 wsrep_sst_method=mariabackup
-wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% else %}
 wsrep_sst_method=rsync
 {% endif %}

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -27,7 +27,7 @@ wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariad
 
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
 wsrep_sst_method=mariabackup
-wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% else %}
 wsrep_sst_method=rsync
 {% endif %}

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -27,7 +27,7 @@ wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariad
 
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
 wsrep_sst_method=mariabackup
-wsrep_sst_auth="{{ mariadb_sst_user }}:{{ mariadb_sst_password }}"
+wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% else %}
 wsrep_sst_method=rsync
 {% endif %}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When I implemented the WSREP SST auth configuration I made a typo for the default value of wsrep_sst_auth. It is currently set to the variable used to configure MySQL user instead of pair [username]:[password]. The default value for wsrep_sst_auth should be set to:
```
wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
```

This issue passed through tests because they do not cover the scenario of using mariabackup SST nor TLS encrypted SST. I do not intend to implement it now, maybe someday when more people will use these features.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
