### PR TITLE
add support for galera gmcast.segment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,7 +123,10 @@ galera_extra_wsrep_provider_options: []
 # value is an integer from 0 to 255
 # By default all nodes are placed in the same segment (0)
 # http://galeracluster.com/documentation-webpages/galeraparameters.html#gmcast-segment
-galera_gmcast_segment: "0"
+#
+# Set to true to add `gmcast.segment` in each node,
+# On each node you must define `galera_gmcast_segment` variable
+galera_use_gmcast_segment: false
 
 # Address to listen on for Incremental State Transfer.
 # By default this is the <address>:<port+1> from wsrep_node_address.

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -34,7 +34,9 @@ wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
-wsrep_provider_options="gmcast.segment={{ galera_gmcast_segment }}"
+{% if galera_use_gmcast_segment and (hostvars[node]['galera_gmcast_segment'] is defined) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[node]['galera_gmcast_segment'] | int }}"
+{% endif %}
 wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
 wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"
 wsrep_node_address="{{ galera_wsrep_node_address }}"

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -34,7 +34,9 @@ wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
-wsrep_provider_options="gmcast.segment={{ galera_gmcast_segment }}"
+{% if galera_use_gmcast_segment and (hostvars[node]['galera_gmcast_segment'] is defined) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[node]['galera_gmcast_segment'] | int }}"
+{% endif %}
 wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
 wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"
 wsrep_node_address="{{ galera_wsrep_node_address }}"


### PR DESCRIPTION

## Description
Changed `galera_gmcast_segment` to `galera_use_gmcast_segment` to define if you want or not support for `gmcast.segment`

## Related Issue
See issue #6 .

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.