### PR TITLE
fix CentOS 8

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -79,6 +79,6 @@
   service:
     name: "mariadb"
     state: started
-  become: true
+    become: true
   when: inventory_hostname == galera_mysql_first_node
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -73,12 +73,12 @@
   service:
     name: "mariadb"
     enabled: true
-    become: true
+  become: true
 
 - name: redhat | start only the first node to add users
   service:
     name: "mariadb"
     state: started
-    become: true
+  become: true
   when: inventory_hostname == galera_mysql_first_node
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -73,4 +73,12 @@
   service:
     name: "mariadb"
     enabled: true
+    become: true
+
+- name: redhat | start only the first node to add users
+  service:
+    name: "mariadb"
+    state: started
   become: true
+  when: inventory_hostname == galera_mysql_first_node
+


### PR DESCRIPTION
On RH based ensure server is started so users are created.

## Description
On RH based systems MariaDB is not started immediately after installation.

## Related Issue
Fixes #71 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
