### PR TITLE
delete recurse declaration on directory

### DIFF
--- a/tasks/max-open-files.yml
+++ b/tasks/max-open-files.yml
@@ -4,10 +4,9 @@
   file:
     path: "/etc/systemd/system/mariadb.service.d"
     state: "directory"
-    recurse: true
     owner: "root"
     group: "root"
-    mode: "u=rw,g=r,o=r"
+    mode: "u=rwx,g=rx,o=rx"
   notify: "reload systemd daemon"
   become: true
 

--- a/tasks/oom-score-adjust.yml
+++ b/tasks/oom-score-adjust.yml
@@ -4,7 +4,6 @@
   file:
     path: "/etc/systemd/system/mariadb.service.d"
     state: "directory"
-    recurse: true
     owner: "root"
     group: "root"
     mode: "u=rwx,g=rx,o=rx"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -40,7 +40,6 @@
     path: "/etc/my.cnf.d"
     state: "directory"
     mode: 0755
-    recurse: true
   become: true
   changed_when: false
   when: mariadb_config_overrides is defined


### PR DESCRIPTION
## Description
Delete recurse declaration on directory because that also changed file/folder permissions causing mysqld to be restarted as there always was a change.

When used w/ "directory" file behaves as "mkdir -p /a/b/c/d" creating all the directory structure needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
