### PR TITLE
allow to pass users tls_requires options

### DIFF
--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -10,6 +10,7 @@
     plugin: "{{ item.0.plugin | default(omit) }}"
     plugin_auth_string: "{{ item.0.plugin_auth_string | default(omit) }}"
     plugin_hash_string: "{{ item.0.plugin_hash_string | default(omit) }}"
+    tls_requires: "{{ item.0.tls_requires | default(omit) }}"
     priv: "{{ item.0.priv | default('*.*:USAGE') }}"
     state: "{{ item.0.state | default('present') }}"
   become: true


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

allow to pass mysql users tls_requires options

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
