### PR TITLE
add python-pymysql as prerequisite needed for configure_root_access | updating root passwords

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -6,6 +6,7 @@ mariadb_pre_req_packages:
   - "python3-pymysql"
   - "rsync"
   - "gnupg"
+  - "python-pymysql"
 mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
 mariadb_packages:
   - "mariadb-server"


### PR DESCRIPTION
add python-pymysql as prerequisite

Otherwise will get a error on the tasks ansible-mariadb-galera-cluster : configure_root_access | updating root passwords:
```
TASK [ansible-mariadb-galera-cluster : configure_root_access | updating root passwords] ********************************************************
failed: [sql3] (item=sql3) => {"ansible_loop_var": "item", "changed": false, "item": "sql3", "msg": "The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required."}
```

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
