### PR TITLE
Add a way to update the mysql root password

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ None
 
 [Example playbook](./playbook.yml)
 
+## Update the root password
+
+To update a existing mysql root password:
+- Update the variable `mariadb_mysql_root_password`
+- Run a ansible-playbook within tags updating_root_passwords (`--tags updating_root_passwords`)
+- Re-run a ansible-playbook without tags
+
 ## License
 
 MIT

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -26,6 +26,8 @@
     - "127.0.0.1"
     - "::1"
     - "localhost"
+  tags:
+    - updating_root_passwords
 
 - name: configure_root_access | updating root passwords (allow from anywhere)
   mysql_user:
@@ -42,3 +44,5 @@
   with_items:
     - "%"
   when: galera_allow_root_from_any|bool
+  tags:
+    - updating_root_passwords


### PR DESCRIPTION
Add a way to update the mysql root password
Update the readme to inform how to do it

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix the #86 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
