### PR TITLE
bump ansible min version to 2.10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: 2.10
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
As on the file tasks/mysql_users.yml (tasks `mysql_users | create MySQL users`)
it's use the plugin attribut (added in 2.10 , 0.1.0 of community.mysql)

<!--- Provide a short summary of your changes in the Title above -->

## Description
The role need the ansible version 2.10 to work correclty
Otherwise it's will failed on Tasks `mysql_users | create MySQL users`)

```
TASK [ansible-mariadb-galera-cluster : mysql_users | create MySQL users] *************************************************************************************************************
...

failed: [ XXXX-> XXX] (item=[{'name': 'mysql', 'plugin': 'unix_socket', 'password': '', 'priv': '*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR'}, 'localhost']) => {"ansible_loop_var": "item", "changed": false, "item": [{"name": "mysql", "password": "", "plugin": "unix_socket", "priv": "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"}, "localhost"], "msg": "Unsupported parameters for (mysql_user) module: plugin Supported parameters include: append_privs, ca_cert, check_implicit_admin, client_cert, client_key, config_file, connect_timeout, encrypted, host, host_all, login_host, login_password, login_port, login_unix_socket, login_user, password, priv, sql_log_bin, state, update_password, user"}
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
