### PR TITLE
clustercheck when use galera cluster behind a haproxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -328,3 +328,6 @@ galera_enable_cacti_monitoring: false
 # Define the cacti user info for cacti db monitoring - If used. May remove later.
 cacti_db_password: "cactiuser"
 cacti_db_user: "cactiuser"
+
+# Define if behind a haproxy and need specific tool for it
+galera_enable_hacluster: false

--- a/files/clustercheck
+++ b/files/clustercheck
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Script to make a proxy (ie HAProxy) capable of monitoring Galera Cluster nodes properly
+#
+# Author: Olaf van Zandwijk <olaf.vanzandwijk@nedap.com>
+# Author: Raghavendra Prabhu <raghavendra.prabhu@percona.com>
+#
+# Documentation and download: https://github.com/olafz/percona-clustercheck
+#
+# Based on the original script from Unai Rodriguez
+#
+
+if [[ $1 == '-h' || $1 == '--help' ]];then
+    echo "Usage: $0 <user> <pass> <available_when_donor=0|1> <log_file> <available_when_readonly=0|1> <defaults_extra_file>"
+    exit
+fi
+
+# if the disabled file is present, return 503. This allows
+# admins to manually remove a node from a cluster easily.
+if [ -e "/var/tmp/clustercheck.disabled" ]; then
+    # Shell return-code is 1
+    echo -en "HTTP/1.1 503 Service Unavailable\r\n"
+    echo -en "Content-Type: text/plain\r\n"
+    echo -en "Connection: close\r\n"
+    echo -en "Content-Length: 51\r\n"
+    echo -en "\r\n"
+    echo -en "Galera Cluser Node is manually disabled.\r\n"
+    sleep 0.1
+    exit 1
+fi
+
+set -e
+
+if [ -f /etc/sysconfig/clustercheck ]; then
+        source /etc/sysconfig/clustercheck
+fi
+
+MYSQL_USERNAME="root"
+MYSQL_PASSWORD=""
+AVAILABLE_WHEN_DONOR=${AVAILABLE_WHEN_DONOR:-0}
+ERR_FILE="${ERR_FILE:-/dev/null}"
+AVAILABLE_WHEN_READONLY=${AVAILABLE_WHEN_READONLY:-0}
+DEFAULTS_EXTRA_FILE=${DEFAULTS_EXTRA_FILE:-/root/.my.cnf}
+
+#Timeout exists for instances where mysqld may be hung
+TIMEOUT=10
+
+EXTRA_ARGS=""
+if [[ -n "$MYSQL_USERNAME" ]]; then
+    EXTRA_ARGS="$EXTRA_ARGS --user=${MYSQL_USERNAME}"
+fi
+if [[ -n "$MYSQL_PASSWORD" ]]; then
+    EXTRA_ARGS="$EXTRA_ARGS --password=${MYSQL_PASSWORD}"
+fi
+if [[ -r $DEFAULTS_EXTRA_FILE ]];then
+    MYSQL_CMDLINE="mysql --defaults-extra-file=$DEFAULTS_EXTRA_FILE -nNE --connect-timeout=$TIMEOUT \
+                    ${EXTRA_ARGS}"
+else
+    MYSQL_CMDLINE="mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
+fi
+#
+# Perform the query to check the wsrep_local_state
+#
+WSREP_STATUS=$($MYSQL_CMDLINE -e "SHOW STATUS LIKE 'wsrep_local_state';" \
+    2>"${ERR_FILE}" | tail -1 2>>"${ERR_FILE}")
+
+if [[ ${WSREP_STATUS} ==  4 ]] || [[ ${WSREP_STATUS} == 2 && ${AVAILABLE_WHEN_DONOR} == 1 ]]
+then
+    # Check only when set to 0 to avoid latency in response.
+    if [[ $AVAILABLE_WHEN_READONLY -eq 0 ]];then
+        READ_ONLY=$($MYSQL_CMDLINE -e "SHOW GLOBAL VARIABLES LIKE 'read_only';" \
+                    2>${ERR_FILE} | tail -1 2>>${ERR_FILE})
+
+        if [[ "${READ_ONLY}" == "ON" ]];then
+            # Galera Cluser node local state is 'Synced', but it is in
+            # read-only mode. The variable AVAILABLE_WHEN_READONLY is set to 0.
+            # => return HTTP 503
+            # Shell return-code is 1
+            echo -en "HTTP/1.1 503 Service Unavailable\r\n"
+            echo -en "Content-Type: text/plain\r\n"
+            echo -en "Connection: close\r\n"
+            echo -en "Content-Length: 43\r\n"
+            echo -en "\r\n"
+            echo -en "Galera Cluser Node is read-only.\r\n"
+            sleep 0.1
+            exit 1
+        fi
+    fi
+    # Galera Cluser node local state is 'Synced' => return HTTP 200
+    # Shell return-code is 0
+    echo -en "HTTP/1.1 200 OK\r\n"
+    echo -en "Content-Type: text/plain\r\n"
+    echo -en "Connection: close\r\n"
+    echo -en "Content-Length: 40\r\n"
+    echo -en "\r\n"
+    echo -en "Galera Cluser Node is synced.\r\n"
+    sleep 0.1
+    exit 0
+else
+    # Galera Cluser node local state is not 'Synced' => return HTTP 503
+    # Shell return-code is 1
+    echo -en "HTTP/1.1 503 Service Unavailable\r\n"
+    echo -en "Content-Type: text/plain\r\n"
+    echo -en "Connection: close\r\n"
+    echo -en "Content-Length: 44\r\n"
+    echo -en "\r\n"
+    echo -en "Galera Cluser Node is not synced.\r\n"
+    sleep 0.1
+    exit 1
+fi

--- a/tasks/cluster_check.yml
+++ b/tasks/cluster_check.yml
@@ -1,0 +1,51 @@
+---
+# From https://github.com/olafz/percona-clustercheck/blob/master/clustercheck
+
+#Copy the clustercheck from the repository to /usr/bin and make it executable.
+- name: Copy clustercheck
+  copy:
+    src: clustercheck
+    dest: /usr/bin/clustercheck
+    mode: '0555'
+
+#Then copy the mysqlck.socket and mysqlchk@.service files (under systemd) in the repository to /usr/lib/systemd/system and make them world-readable.
+
+- name: Copy mysqlchk@.service
+  copy:
+    dest: /etc/systemd/system/mysqlchk@.service
+    content: |
+      [Unit]
+      Description=Galera Cluster node check service
+
+      [Service]
+      Type=oneshot
+      ExecStart=-/usr/bin/clustercheck
+      StandardInput=socket
+      TimeoutStopSec=5
+
+- name: Copy mysqlck.socket
+  copy:
+    dest: /etc/systemd/system/mysqlchk.socket
+    content: |
+      [Unit]
+      Description=Galera Cluster node check socket
+      PartOf=mysqlchk@.service
+
+      [Socket]
+      ListenStream=9200
+      Accept=yes
+      TriggerLimitIntervalSec=0
+      TriggerLimitBurst=0
+
+      [Install]
+      WantedBy=sockets.target
+
+#To activate the socket
+
+- name: enable mysqlchk.socket
+  systemd:
+    name: mysqlchk.socket
+    state: started
+    enabled: yes
+
+# Systemd will now service requests to port 9200 with the clustercheck script, and HAproxy is ready to check MySQL via HTTP port 9200.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,3 +69,8 @@
   tags:
     - config_cacti_monitoring
   when: galera_enable_cacti_monitoring
+
+- import_tasks: cluster_check.yml
+  tags:
+    - config_hacluster
+  when: galera_enable_hacluster


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
provide a way to check if mariadb is up and running and check if the node is sync with the galera cluster
Used by HaProxy to remove a node of  pool of sql galera node if it's not sync with node of the galera Cluster


Configuration example of HaProxy
```
  listen mysql
    balance leastconn
    bind    192.168.0.1:3306
    mode    tcp
    option clitcpka
    option srvtcpka
    option tcplog
    option httpchk
    server sql1 192.168.0.2:3306 check port 9200 weight 1 inter 10s downinter 5s rise 15 slowstart 60s
    server sql2 192.168.0.3:3306 check port 9200 weight 1 inter 10s downinter 5s rise 15 slowstart 60s
    server sql3 192.168.0.4:3306 check port 9200 weight 1 inter 10s downinter 5s rise 15 slowstart 60s
```


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
