### PR TITLE
add configuration variable mariadb_innodb_lock_wait_timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -228,6 +228,9 @@ mariadb_one_gig_bytes: "{{ 1024 * 1024 * 1024 }}"
 # Maximum allowed concurrent connections. MySQL default is 151
 mariadb_max_connections: "auto"
 
+# The length of time in seconds an InnoDB transaction waits for a row lock before giving up.
+mariadb_innodb_lock_wait_timeout: "50"
+
 # Queries that take more time than 'mariadb_long_query_time' to complete are
 # considered as slow. Values in seconds or 'auto' for the MySQL default (10)
 # phpmyadmin recommends this value to be set to "5" or less.

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -40,6 +40,9 @@ collation-server      = {{ mariadb_collation_server }}
 {% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
 innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
 {% endif %}
+{% if mariadb_innodb_lock_wait_timeout | default('50') != "50" %}
+innodb_lock_wait_timeout = {{ mariadb_innodb_lock_wait_timeout }}
+{% endif %}
 {% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
 innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
 {% endif %}


### PR DESCRIPTION
Was needed to follow slurmdbd recommandation ( 900 instead of the
default value 50)

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Add the configuration option innodb_lock_wait_timeout
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
