### PR TITLE
Removed:

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,6 @@ mariadb_mysql_mem_multiplier: .25
 
 mariadb_mysql_settings:
   datadir: "/var/lib/mysql"
-  expire_logs_days: 10
   #Default is 16M
   key_buffer_size: "{{ (ansible_memtotal_mb | int * mariadb_mysql_mem_multiplier) | round | int }}M"
   max_allowed_packet: "16M"
@@ -47,7 +46,6 @@ mariadb_mysql_settings:
   query_cache_size: "16M"
   # MariaDB default: https://mariadb.com/kb/en/server-system-variables/#thread_cache_size
   thread_cache_size: 256
-  thread_stack: "192K"
 
 # Define TLS certs & keys which will be used to encrypt mysql, WSREP, SST connections
 # This variable should have defined exactly three items, any other item count is handled like none.
@@ -199,12 +197,6 @@ mariadb_timeout_start_sec: 0
 # Set to a specific amount in bytes or to "auto" for server defaults.
 mariadb_innodb_buffer_pool_size: "auto"
 
-# How many pool instances to use for the buffer pool
-# Each instance should ideally be at least 1GB in size.
-# Set to "auto" for server defaults
-# https://mariadb.com/kb/en/innodb-buffer-pool/#innodb_buffer_pool_instances
-mariadb_innodb_buffer_pool_instances: "auto"
-
 # Automatic pool size tuning example:
 
 # What percentage of system memory to use for InnoDB row cache
@@ -215,16 +207,6 @@ mariadb_innodb_mem_multiplier: 0.5
 # mariadb_innodb_buffer_pool_size: >-
 #   {{ (ansible_memtotal_mb|int * mariadb_innodb_mem_multiplier * 1024 * 1024)
 #   | round | int }}
-
-# Bytes in a gigabyte. Only used internally to calculate the number of
-# pool instances in "mariadb_innodb_buffer_pool_instances"
-mariadb_one_gig_bytes: "{{ 1024 * 1024 * 1024 }}"
-
-# Calculate the amount of instances so that they are about 1G in size
-# mariadb_innodb_buffer_pool_instances: >-
-#   {% if mariadb_innodb_buffer_pool_size|int > mariadb_one_gig_bytes|int %}{{
-#   (mariadb_innodb_buffer_pool_size|int / mariadb_one_gig_bytes|int) |abs |int
-#   }}{% else %}1{% endif %}
 
 # Maximum allowed concurrent connections. MySQL default is 151
 mariadb_max_connections: "auto"

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -22,9 +22,6 @@ collation-server      = {{ mariadb_collation_server }}
 {% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
 innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
 {% endif %}
-{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
-innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
-{% endif %}
 {% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
 innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
 {% endif %}

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -22,9 +22,6 @@ collation-server      = {{ mariadb_collation_server }}
 {% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
 innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
 {% endif %}
-{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
-innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
-{% endif %}
 {% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
 innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
 {% endif %}

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -11,21 +11,18 @@ socket = {{ mariadb_login_unix_socket }}
 [mysqld]
 basedir = /usr
 datadir	= {{ mariadb_mysql_settings['datadir'] }}
-expire_logs_days = {{ mariadb_mysql_settings['expire_logs_days'] }}
 key_buffer_size = {{ mariadb_mysql_settings['key_buffer_size'] }}
 lc-messages-dir = /usr/share/mysql
 log_error = /var/log/mysql/error.log
 max_allowed_packet = {{ mariadb_mysql_settings['max_allowed_packet'] }}
 max_binlog_size = {{ mariadb_mysql_settings['max_binlog_size'] }}
 myisam-recover = BACKUP
-pid-file = /var/run/mysqld/mysqld.pid
 port = {{ mariadb_mysql_port }}
 query_cache_limit = {{ mariadb_mysql_settings['query_cache_limit'] }}
 query_cache_size = {{ mariadb_mysql_settings['query_cache_size'] }}
 skip-external-locking
 socket = {{ mariadb_login_unix_socket }}
 thread_cache_size = {{ mariadb_mysql_settings['thread_cache_size'] }}
-thread_stack = {{ mariadb_mysql_settings['thread_stack'] }}
 tmpdir = /tmp
 user = mysql
 
@@ -42,9 +39,6 @@ innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
 {% endif %}
 {% if mariadb_innodb_lock_wait_timeout | default('50') != "50" %}
 innodb_lock_wait_timeout = {{ mariadb_innodb_lock_wait_timeout }}
-{% endif %}
-{% if mariadb_innodb_buffer_pool_instances | default('auto') != "auto" %}
-innodb_buffer_pool_instances = {{ mariadb_innodb_buffer_pool_instances }}
 {% endif %}
 {% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
 innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}


### PR DESCRIPTION
Remove deprecated variables

## Description
- `expire_logs_days` - deprecated in MySQL, MariaDB added the new variable `binlog_expire_logs_seconds` - if anyone needs that they can use via overrides option
- `pid-file` - remove it as this is not needed in SystemD servers
- `innodb_buffer_pool_instances` - deprecated as of MariaDB 10.5.1, removed from MariaDB 10.6 - there is no problem in removing it even for old installs
- `thread_stack` - is set by default at 192K but starting from MariaDB 10.0 it is by default 288K

## Related Issue
Closes #76

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
