### PR TITLE
Debian11

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -24,6 +24,7 @@ jobs:
           # - debian8
           - debian9
           - debian10
+          - debian11
           # - fedora
           # - ubuntu1604
           - ubuntu1804

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,11 @@ debian10:
   script:
     - molecule test --scenario-name debian10
 
+debian11:
+  stage: molecule-test
+  script:
+    - molecule test --scenario-name debian11
+
 #fedora:
 #  stage: molecule-test
 #  script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - molecule_distro=centos8
   - molecule_distro=debian9
   - molecule_distro=debian10
+  - molecule_distro=debian11
 #  - molecule_distro=fedora
   - molecule_distro=ubuntu1604
   - molecule_distro=ubuntu1804

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        - bullseye
     - name: Fedora
       versions:
         - 32

--- a/molecule/debian11/INSTALL.rst
+++ b/molecule/debian11/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+  options:
+    role-file: requirements.yml
+driver:
+  name: docker
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: node1
+    image: jrei/systemd-debian:10
+    privileged: true
+    command: /lib/systemd/systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - galera-cluster-nodes
+  - name: node2
+    image: jrei/systemd-debian:10
+    privileged: true
+    command: /lib/systemd/systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - galera-cluster-nodes
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../shared/converge.yml
+    prepare: ../shared/prepare.yml
+verifier:
+  name: ansible

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -12,7 +12,7 @@ lint: |
   flake8
 platforms:
   - name: node1
-    image: jrei/systemd-debian:10
+    image: jrei/systemd-debian:11
     privileged: true
     command: /lib/systemd/systemd
     volumes:
@@ -20,7 +20,7 @@ platforms:
     groups:
       - galera-cluster-nodes
   - name: node2
-    image: jrei/systemd-debian:10
+    image: jrei/systemd-debian:11
     privileged: true
     command: /lib/systemd/systemd
     volumes:

--- a/molecule/debian11/verify.yml
+++ b/molecule/debian11/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/templates/etc/mysql/debian.cnf.j2
+++ b/templates/etc/mysql/debian.cnf.j2
@@ -12,12 +12,20 @@
 # Automatically generated for Debian scripts. DO NOT TOUCH! (opps)
 [client]
 host     = localhost
+{% if ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11 %}
+user     = root
+{% else %}
 user     = debian-sys-maint
+{% endif %}
 password = {{ mariadb_mysql_root_password }}
 socket   = {{ mariadb_login_unix_socket }}
 [mysql_upgrade]
 host     = localhost
+{% if ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11 %}
+user     = root
+{% else %}
 user     = debian-sys-maint
+{% endif %}
 password = {{ mariadb_mysql_root_password }}
 socket   = {{ mariadb_login_unix_socket }}
 basedir  = /usr

--- a/templates/etc/mysql/debian.cnf.j2
+++ b/templates/etc/mysql/debian.cnf.j2
@@ -1,3 +1,13 @@
+{% if ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11 %}
+# THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE.
+# This file exists only for backwards compatibility for
+# tools that run '--defaults-file=/etc/mysql/debian.cnf'
+# and have root level access to the local filesystem.
+# With those permissions one can run 'mariadb' directly
+# anyway thanks to unix socket authentication and hence
+# this file is useless. See package README for more info.
+
+{% endif %}
 # {{ ansible_managed }}
 # Automatically generated for Debian scripts. DO NOT TOUCH! (opps)
 [client]

--- a/templates/etc/mysql/debian.cnf.j2
+++ b/templates/etc/mysql/debian.cnf.j2
@@ -12,7 +12,8 @@
 # Automatically generated for Debian scripts. DO NOT TOUCH! (opps)
 [client]
 host     = localhost
-{% if ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11 %}
+{% if ((ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11) or
+       (ansible_distribution | lower == 'ubuntu' and ansible_distribution_major_version | int >= 20)) %}
 user     = root
 {% else %}
 user     = debian-sys-maint
@@ -21,7 +22,8 @@ password = {{ mariadb_mysql_root_password }}
 socket   = {{ mariadb_login_unix_socket }}
 [mysql_upgrade]
 host     = localhost
-{% if ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11 %}
+{% if ((ansible_distribution | lower == 'debian' and ansible_distribution_major_version | int >= 11) or
+       (ansible_distribution | lower == 'ubuntu' and ansible_distribution_major_version | int >= 20)) %}
 user     = root
 {% else %}
 user     = debian-sys-maint

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -1,0 +1,22 @@
+---
+mariadb_login_unix_socket: "/var/run/mysqld/mysqld.sock"
+mariadb_pre_req_packages:
+  - "apt-transport-https"
+  - "software-properties-common"
+  - "python3-pymysql"
+  - "rsync"
+  - "gnupg"
+mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
+mariadb_packages:
+  - "mariadb-server"
+mariabackup_packages:
+  - "mariadb-backup"
+mariadb_certificates_dir: "/etc/mysql/certificates"
+mariadb_systemd_service_name: "mysql"
+mariadb_confs:
+  - "etc/mysql/debian.cnf"
+  - "etc/mysql/my.cnf"
+  - "etc/mysql/conf.d/galera.cnf"
+mariadb_temp_confs:
+  - "etc/mysql/conf.d/galera.cnf"
+galera_wsrep_provider: "/usr/lib/galera/libgalera_smm.so"

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -14,6 +14,7 @@ mariabackup_packages:
 mariadb_certificates_dir: "/etc/mysql/certificates"
 mariadb_systemd_service_name: "mariadb"
 mariadb_confs:
+  - "etc/mysql/debian.cnf"
   - "etc/mysql/my.cnf"
   - "etc/mysql/conf.d/galera.cnf"
 mariadb_temp_confs:

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -12,7 +12,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mysql"
+mariadb_systemd_service_name: "mariadb"
 mariadb_confs:
   - "etc/mysql/my.cnf"
   - "etc/mysql/conf.d/galera.cnf"

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -14,7 +14,6 @@ mariabackup_packages:
 mariadb_certificates_dir: "/etc/mysql/certificates"
 mariadb_systemd_service_name: "mysql"
 mariadb_confs:
-  - "etc/mysql/debian.cnf"
   - "etc/mysql/my.cnf"
   - "etc/mysql/conf.d/galera.cnf"
 mariadb_temp_confs:


### PR DESCRIPTION
As debian 11 aka. bullseye comes with python3 as default, the `python-pymysql` package is not available anymore.

## Description
Created new  var file `vars/debian-11.yml`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
