### PR TITLE
ensure the service is running ...

### DIFF
--- a/molecule/centos8/molecule.yml
+++ b/molecule/centos8/molecule.yml
@@ -12,7 +12,7 @@ lint: |
   flake8
 platforms:
   - name: node1
-    image: jrei/systemd-centos:8
+    image: mrlesmithjr/centos:8
     privileged: true
     command: /usr/sbin/init
     volumes:

--- a/molecule/centos8/molecule.yml
+++ b/molecule/centos8/molecule.yml
@@ -12,7 +12,7 @@ lint: |
   flake8
 platforms:
   - name: node1
-    image: mrlesmithjr/centos:8
+    image: jrei/systemd-centos:8
     privileged: true
     command: /usr/sbin/init
     volumes:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,11 +42,13 @@
     - install
     - config
 
-- name: "ensure {{ mariadb_systemd_service_name }} is started"
+# ensure the first node is running in order to add users
+- name: "ensure {{ mariadb_systemd_service_name }} is started on first node"
   service:
     name: "{{ mariadb_systemd_service_name }}"
     state: "started"
   become: true
+  when: inventory_hostname == galera_mysql_first_node
 
 - import_tasks: mysql_users.yml
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,12 @@
     - install
     - config
 
+- name: "ensure {{ mariadb_systemd_service_name }} is started"
+  service:
+    name: "{{ mariadb_systemd_service_name }}"
+    state: "started"
+  become: true
+
 - import_tasks: mysql_users.yml
   tags:
     - config

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -73,10 +73,3 @@
     name: "mariadb"
     enabled: true
   become: true
-
-- name: redhat | start only the first node to add users
-  service:
-    name: "mariadb"
-    state: started
-  become: true
-  when: inventory_hostname == galera_mysql_first_node


### PR DESCRIPTION
… as the creation of the _user_ or _db_ will fail on a stopped service.

This is esp. for subsequent runs after adding _users_ or _db_'s to be created.
If the service was stopped, the creation of the items will fail with the (hidden) error message:
`Can't connect to MySQL server on 'localhost'`

## Description

The PR just ensures the required mysql/mysqld/mariadb service is running before it attempts to create the desired items.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
