### PR TITLE
Extra options for wsrep_slave_threads

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,6 +105,11 @@ galera_wsrep_node_address: "{{ galera_cluster_bind_address }}:{{ galera_wsrep_no
 # Defines wsrep node port
 galera_wsrep_node_address_port: 4567
 
+# Define the number of wsrep_slave_threads:
+# - if `auto` we will use "number of vCPUs - 1"
+# - else the value define here is used
+galera_wsrep_slave_threads: 1
+
 # Define the name of the cluster
 galera_cluster_name: "vagrant-test"
 

--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -79,7 +79,11 @@ innodb_autoinc_lock_mode=2
 bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
-#wsrep_slave_threads=1
+{% if galera_wsrep_slave_threads == "auto" %}
+wsrep_slave_threads={{ 1 if (ansible_processor_vcpus <= 1) else (ansible_processor_vcpus - 1) }}
+{% else %}
+wsrep_slave_threads={{ galera_wsrep_slave_threads }}
+{% endif %}
 #innodb_flush_log_at_trx_commit=0
 
 {% if galera_enable_galera_monitoring_script %}

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -79,7 +79,11 @@ innodb_autoinc_lock_mode=2
 bind-address={{ mariadb_bind_address }}
 #
 # Optional setting
-#wsrep_slave_threads=1
+{% if galera_wsrep_slave_threads == "auto" %}
+wsrep_slave_threads={{ 1 if (ansible_processor_vcpus <= 1) else (ansible_processor_vcpus - 1) }}
+{% else %}
+wsrep_slave_threads={{ galera_wsrep_slave_threads }}
+{% endif %}
 #innodb_flush_log_at_trx_commit=0
 
 {% if galera_enable_galera_monitoring_script %}


### PR DESCRIPTION
Manage value for wsrep_slave_threads

## Description
The number of WSREP threads appliers.
I have left the default of 1 and the old behavior as it was. 
I added the option of `auto` where it computes as suggested by Galera documentation to use the number of vCPUs. I subtracted 1 for OS requirements.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
