### PR TITLE
add socket line in /root/.my.cnf

### DIFF
--- a/tasks/cacti.yml
+++ b/tasks/cacti.yml
@@ -2,7 +2,7 @@
 - name: cacti_monitoring | adding cacti db user for monitoring
   mysql_user:
     host: "{{ cacti_server }}"
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
     name: "{{ cacti_db_user }}"
     password: "{{ cacti_db_password }}"
     priv: "*.*:SUPER,PROCESS"
@@ -17,7 +17,7 @@
 - name: cacti_monitoring | adding cacti db user for monitoring
   mysql_user:
     host: "{{ cacti_server_fqdn }}"
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
     name: "{{ cacti_db_user }}"
     password: "{{ cacti_db_password }}"
     priv: "*.*:SUPER,PROCESS"

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -13,7 +13,7 @@
 - name: configure_root_access | updating root passwords
   mysql_user:
     host: "{{ item }}"
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
     name: "root"
     password: "{{ mariadb_mysql_root_password }}"
   become: true
@@ -32,7 +32,7 @@
 - name: configure_root_access | updating root passwords (allow from anywhere)
   mysql_user:
     host: "{{ item }}"
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
     name: "root"
     password: "{{ mariadb_mysql_root_password }}"
     priv: "*.*:ALL,GRANT"

--- a/tasks/mysql_databases.yml
+++ b/tasks/mysql_databases.yml
@@ -6,7 +6,7 @@
   mysql_db:
     name: "{{ item.name }}"
     state: present
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
   with_items: "{{ mariadb_databases }}"
   become: true
   register: _db
@@ -26,7 +26,7 @@
     name: "{{ item.item.name }}"
     state: import
     target: "/tmp/{{ item.item.init_script | basename }}"
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
   with_items: "{{ _db.results }}"
   become: true
   when:

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -4,7 +4,7 @@
     append_privs: "{{ item.0.append_privs | default('no') }}"
     encrypted: "{{ item.0.encrypted | default('no') }}"
     host: "{{ item.1 }}"
-    login_unix_socket: "{{ mariadb_login_unix_socket }}"
+    login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
     name: "{{ item.0.name }}"
     password: "{{ item.0.password | default(omit) }}"
     plugin: "{{ item.0.plugin | default(omit) }}"

--- a/templates/root/my.cnf.j2
+++ b/templates/root/my.cnf.j2
@@ -1,3 +1,4 @@
 [client]
 user=root
 password={{ mariadb_mysql_root_password }}
+socket={{ mariadb_login_unix_socket }}


### PR DESCRIPTION
Add socket in /root/.my.cnf

## Description
By adding the line w/ socket in my.cnf we do not have to add the option `login_unix_socket` in all further communication w/ the cluster via Ansible.

I was thinking in doing the change in two steps. First I added the line in my.cnf and added `default(omit)` for all `login_unix_socket`. In the next phase we can completely discard the lines w/ `login_unix_socket`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
