### PR TITLE
fix systemd service name for ubuntu 20.04

### DIFF
--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mysql"
+mariadb_systemd_service_name: "mariadb"
 mariadb_confs:
   - "etc/mysql/debian.cnf"
   - "etc/mysql/my.cnf"


### PR DESCRIPTION
Use the real service name, as mysql is just a alias for mariadb.

## Description
change systemd service name for ubuntu 20.04 to `mariadb`.

## Related Issue
#104 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
