### PR TITLE
Fix sst unix socket

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -117,8 +117,7 @@ galera_cluster_name: "vagrant-test"
 galera_cluster_nodes_group: "galera-cluster-nodes"
 
 # https://mariadb.com/kb/en/mariadb/wsrep_provider_options/
-galera_extra_wsrep_provider_options:
-  []
+galera_extra_wsrep_provider_options: []
   # evs.auto_evict: 1
   # evs.delayed_margin: 'PT5S'
   # evs.delayed_keep_period: 'PT45S'
@@ -160,15 +159,9 @@ galera_sst_tls_enabled: false
 # https://mariadb.com/kb/en/authentication-plugin-unix-socket.
 # If you need to use password auth change set mariadb_sst_user.plugin to mysql_native_password
 # and set mariadb_sst_password.
+mariadb_sst_user_plugin: "unix_socket"
 mariadb_sst_username: "mysql"
 mariadb_sst_password: ""
-mariadb_sst_user:
-  - name: "{{ mariadb_sst_username }}"
-    hosts:
-      - "localhost"
-    plugin: "unix_socket"
-    password: "{{ mariadb_sst_password }}"
-    priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
 
 # This option defines the wsrep_sst_method that should be used by the cluster.
 # Possible options:

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -12,7 +12,7 @@ lint: |
   flake8
 platforms:
   - name: node1
-    image: jrei/systemd-centos:7
+    image: mrlesmithjr/centos:7
     privileged: true
     command: /usr/sbin/init
     volumes:
@@ -20,7 +20,7 @@ platforms:
     groups:
       - galera-cluster-nodes
   - name: node2
-    image: jrei/systemd-centos:7
+    image: mrlesmithjr/centos:7
     privileged: true
     command: /usr/sbin/init
     volumes:

--- a/molecule/centos8/molecule.yml
+++ b/molecule/centos8/molecule.yml
@@ -12,7 +12,7 @@ lint: |
   flake8
 platforms:
   - name: node1
-    image: jrei/systemd-centos:8
+    image: mrlesmithjr/centos:8
     privileged: true
     command: /usr/sbin/init
     volumes:
@@ -20,7 +20,7 @@ platforms:
     groups:
       - galera-cluster-nodes
   - name: node2
-    image: jrei/systemd-centos:8
+    image: mrlesmithjr/centos:8
     privileged: true
     command: /usr/sbin/init
     volumes:

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -15,7 +15,7 @@
   assert:
     that:
       - mariadb_sst_user_plugin == "unix_socket"
-      - mariadb_sst_password != ""
+      - mariadb_sst_password | length != 0
     fail_msg: >-
       When the mariadb_sst_user_plugin is set to unix_socket
       the mariadb_sst_password should not be set because it is ignored.
@@ -27,7 +27,7 @@
   assert:
     that:
       - mariadb_sst_user_plugin == "mysql_native_password"
-      - mariadb_sst_password == ""
+      - mariadb_sst_password | length == 0
     fail_msg: >-
       When the mariadb_sst_user_plugin is set to mysql_native_password
       the mariadb_sst_password should also be set.

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -14,11 +14,11 @@
 - name: When mariadb_sst_username is unix_socket, the mariadb_sst_password should not be set
   assert:
     that:
-      - mariadb_sst_user_plugin == "unix_socket"
       - mariadb_sst_password == ""
     fail_msg: >-
       When the mariadb_sst_user_plugin is set to unix_socket
       the mariadb_sst_password should not be set because it is ignored.
+  when: mariadb_sst_user_plugin == "unix_socket"
   tags:
     - install
     - config
@@ -26,11 +26,11 @@
 - name: When mariadb_sst_username is mysql_native_password, mariadb_sst_password should also be set
   assert:
     that:
-      - mariadb_sst_user_plugin == "mysql_native_password"
       - mariadb_sst_password != ""
     fail_msg: >-
       When the mariadb_sst_user_plugin is set to mysql_native_password
       the mariadb_sst_password should also be set.
+  when: mariadb_sst_user_plugin == "mysql_native_password"
   tags:
     - install
     - config

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -1,0 +1,36 @@
+---
+
+- name: ensure NIC specified in 'galera_cluster_bind_interface' exists
+  assert:
+    that: galera_cluster_bind_interface in ansible_interfaces
+    fail_msg: >-
+      The NIC name "{{ galera_cluster_bind_interface }}" specified in
+      "galera_cluster_bind_interface" does not exist on the target host.
+      Available interfaces are: "{{ ansible_interfaces | join(',') }}".
+  tags:
+    - install
+    - config
+
+- name: When mariadb_sst_username is unix_socket, the mariadb_sst_password should not be set
+  assert:
+    that:
+      - mariadb_sst_user_plugin == "unix_socket"
+      - mariadb_sst_password != ""
+    fail_msg: >-
+      When the mariadb_sst_user_plugin is set to unix_socket
+      the mariadb_sst_password should not be set because it is ignored.
+  tags:
+    - install
+    - config
+
+- name: When mariadb_sst_username is mysql_native_password, mariadb_sst_password should also be set
+  assert:
+    that:
+      - mariadb_sst_user_plugin == "mysql_native_password"
+      - mariadb_sst_password == ""
+    fail_msg: >-
+      When the mariadb_sst_user_plugin is set to mysql_native_password
+      the mariadb_sst_password should also be set.
+  tags:
+    - install
+    - config

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -15,7 +15,7 @@
   assert:
     that:
       - mariadb_sst_user_plugin == "unix_socket"
-      - mariadb_sst_password | length != 0
+      - mariadb_sst_password == ""
     fail_msg: >-
       When the mariadb_sst_user_plugin is set to unix_socket
       the mariadb_sst_password should not be set because it is ignored.
@@ -27,7 +27,7 @@
   assert:
     that:
       - mariadb_sst_user_plugin == "mysql_native_password"
-      - mariadb_sst_password | length == 0
+      - mariadb_sst_password != ""
     fail_msg: >-
       When the mariadb_sst_user_plugin is set to mysql_native_password
       the mariadb_sst_password should also be set.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,16 +11,10 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
 
-- name: ensure NIC specified in 'galera_cluster_bind_interface' exists
-  assert:
-    that: galera_cluster_bind_interface in ansible_interfaces
-    fail_msg: >-
-      The NIC name "{{ galera_cluster_bind_interface }}" specified in
-      "galera_cluster_bind_interface" does not exist on the target host.
-      Available interfaces are: "{{ ansible_interfaces | join(',') }}".
+- import_tasks: checks.yml
   tags:
+    - always
     - install
-    - config
 
 - import_tasks: debian.yml
   tags:

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -1,4 +1,39 @@
 ---
+
+- name: "Check if {{ mariadb_sst_username }} exists in the system"
+  block:
+    - name: "Check if {{ mariadb_sst_username }} exists in the system"
+      getent:
+        database: passwd
+        key: "{{ mariadb_sst_username }}"
+      ignore_errors: true
+      register: mariadb_sst_username__found
+    - name: Fail if the above user does not exist
+      fail:
+        msg: >-
+          The plugin for mariadb_sst_username was
+          set to unix_socket but the user does not exist.
+      when: mariadb_sst_username__found.failed
+  when: mariadb_sst_user_plugin == "unix_socket"
+
+- name: Create definition for mariadb_sst_user via unix_socket
+  set_fact:
+    mariadb_sst_user:
+      - name: "{{ mariadb_sst_username }}"
+        hosts: "localhost"
+        plugin: "{{ mariadb_sst_user_plugin }}"
+        priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
+  when: mariadb_sst_user_plugin == "unix_socket"
+
+- name: Create definition for mariadb_sst_user via mysql_native_password
+  set_fact:
+    mariadb_sst_user:
+      - name: "{{ mariadb_sst_username }}"
+        hosts: "localhost"
+        password: "{{ mariadb_sst_password }}"
+        priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
+  when: mariadb_sst_user_plugin == "mysql_native_password"
+
 - name: mysql_users | create MySQL users
   mysql_user:
     append_privs: "{{ item.0.append_privs | default('no') }}"

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -14,6 +14,8 @@
           The plugin for mariadb_sst_username was
           set to unix_socket but the user does not exist.
       when: mariadb_sst_username__found.failed
+  delegate_to: "{{ galera_mysql_first_node }}"
+  run_once: true
   when: mariadb_sst_user_plugin == "unix_socket"
 
 - name: Create definition for mariadb_sst_user via unix_socket
@@ -23,6 +25,8 @@
         hosts: "localhost"
         plugin: "{{ mariadb_sst_user_plugin }}"
         priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
+  delegate_to: "{{ galera_mysql_first_node }}"
+  run_once: true
   when: mariadb_sst_user_plugin == "unix_socket"
 
 - name: Create definition for mariadb_sst_user via mysql_native_password
@@ -32,6 +36,8 @@
         hosts: "localhost"
         password: "{{ mariadb_sst_password }}"
         priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
+  delegate_to: "{{ galera_mysql_first_node }}"
+  run_once: true
   when: mariadb_sst_user_plugin == "mysql_native_password"
 
 - name: mysql_users | create MySQL users

--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -22,7 +22,8 @@
   set_fact:
     mariadb_sst_user:
       - name: "{{ mariadb_sst_username }}"
-        hosts: "localhost"
+        hosts:
+          - 'localhost'
         plugin: "{{ mariadb_sst_user_plugin }}"
         priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
   delegate_to: "{{ galera_mysql_first_node }}"
@@ -33,7 +34,8 @@
   set_fact:
     mariadb_sst_user:
       - name: "{{ mariadb_sst_username }}"
-        hosts: "localhost"
+        hosts:
+          - 'localhost'
         password: "{{ mariadb_sst_password }}"
         priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
   delegate_to: "{{ galera_mysql_first_node }}"

--- a/tasks/system_performance_tuning.yml
+++ b/tasks/system_performance_tuning.yml
@@ -1,15 +1,15 @@
 ---
-- include: max-open-files.yml
+- import_tasks: max-open-files.yml
   when: >
     ansible_service_mgr == "systemd" and
     mariadb_max_open_files != 0
 
-- include: oom-score-adjust.yml
+- import_tasks: oom-score-adjust.yml
   when: >
     ansible_service_mgr == "systemd" and
     mariadb_oom_score_adjust != 0
 
-- include: timeout-start-sec.yml
+- import_tasks: timeout-start-sec.yml
   when: >
     ansible_service_mgr == "systemd" and
     mariadb_timeout_start_sec != 0


### PR DESCRIPTION
Improvements for SST user

## Description
+ more detailed messages for each fail case
+ error out when using `unix_socket` and setting a password
+ error out when using `unix_socket` with a non existent system user
+ error out when using mysql native password and not setting a password
* minor - change `include` to `import_tasks` in `system_performance_tuning.yml`

## Related Issue
Fixes #110 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
