### PR TITLE
template: use inventory_hostname to access galera_gmcast_segment

### DIFF
--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -34,8 +34,8 @@ wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
-{% if galera_use_gmcast_segment and (hostvars[node]['galera_gmcast_segment'] is defined) %}
-wsrep_provider_options="gmcast.segment={{ hostvars[node]['galera_gmcast_segment'] | int }}"
+{% if galera_use_gmcast_segment and (hostvars[inventory_hostname]['galera_gmcast_segment'] is defined) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[inventory_hostname]['galera_gmcast_segment'] | int }}"
 {% endif %}
 wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
 wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
`templates/etc/mysql/conf.d/galera.cnf.j2` uses `node` as key to access the node's `galera_gmcast_segment`. However `node` was not defined in scope. Should use `inventory_hostname` instead. Otherwise this error will arise:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'node' is undefined
failed: [g0h2] (item=etc/mysql/conf.d/galera.cnf) => {"ansible_loop_var": "item", "changed": false, "item": "etc/mysql/conf.d/galera.cnf", "msg": "AnsibleUndefinedVariable: 'node' is undefined"}
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
