### PR TITLE
redhat: use variable galera_enable_mariadb_repo

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -9,6 +9,8 @@
     gpgcheck: true
   become: true
   register: "repo_added"
+  when: 
+    - galera_enable_mariadb_repo | bool
 
 # fix for conflicting package from appstream
 - name: redhat | disable appstream mysql/mariadb modules
@@ -17,7 +19,9 @@
     warn: false
   changed_when: false
   become: true
-  when: ansible_distribution_major_version is version('8', '>=')
+  when: 
+    - ansible_distribution_major_version is version('8', '>=') 
+    - galera_enable_mariadb_repo | bool
 
 - name: redhat | clean dnf metadata (centos8 & fedora)
   shell: "dnf clean all && rm -r /var/cache/dnf" # noqa 503
@@ -27,7 +31,8 @@
   when:
     - repo_added.changed
     - ansible_distribution_major_version is version('8', '>=')
-
+    - galera_enable_mariadb_repo | bool
+    
 - name: redhat | installing pre-reqs
   yum:
     name: "{{ mariadb_pre_req_packages }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -9,7 +9,7 @@
     gpgcheck: true
   become: true
   register: "repo_added"
-  when: 
+  when:
     - galera_enable_mariadb_repo | bool
 
 # fix for conflicting package from appstream
@@ -19,8 +19,8 @@
     warn: false
   changed_when: false
   become: true
-  when: 
-    - ansible_distribution_major_version is version('8', '>=') 
+  when:
+    - ansible_distribution_major_version is version('8', '>=')
     - galera_enable_mariadb_repo | bool
 
 - name: redhat | clean dnf metadata (centos8 & fedora)
@@ -32,7 +32,7 @@
     - repo_added.changed
     - ansible_distribution_major_version is version('8', '>=')
     - galera_enable_mariadb_repo | bool
-    
+
 - name: redhat | installing pre-reqs
   yum:
     name: "{{ mariadb_pre_req_packages }}"


### PR DESCRIPTION
…epo  use

## Description
The variable `galera_enable_mariadb_repo` only omits configuration for mariadb repo in Debian. In environments with
limited access to the Internet and using RedHat Satellite to serve reopsitories this behaviour should also be available for RedHat configuration.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
