### PR TITLE
Galera notify : Use the lastest version + add mail header Message-ID

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -305,6 +305,8 @@ galera_notify_smtp_auth: "False"
 galera_notify_smtp_username: ""
 galera_notify_smtp_password: ""
 galera_notify_smtp_port: 25
+# Set to True if you need SMTP over SSL
+galera_notify_smtp_ssl: False
 
 # Defines if cacti monitoring should be enabled for mysql - If used. May remove later.
 galera_enable_cacti_monitoring: false

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -5,9 +5,9 @@
 #
 # Complies with http://www.codership.com/wiki/doku.php?id=notification_command
 #
-# Author: Gabe Guillen <gguillen@gesa.com>
-# Version: 1.3
-# Release: 10/03/2013
+# Author: Gabe Guillen <gabeguillen@outlook.com>
+# Version: 1.5
+# Release: 3/5/2015
 # Use at your own risk.  No warranties expressed or implied.
 #
 
@@ -25,17 +25,18 @@ except ImportError:
     from email.MIMEText import MIMEText
 
 import socket
+import email.utils
 
 # Change this to some value if you don't want your server hostname to show in
 # the notification emails
 THIS_SERVER = socket.gethostname()
 
 # Server hostname or IP address
-mariadb_smtp_server = '{{ galera_notify_smtp_server }}'
+SMTP_SERVER = '{{ galera_notify_smtp_server }}'
 SMTP_PORT = {{ galera_notify_smtp_port }}
 
 # Set to True if you need SMTP over SSL
-SMTP_SSL = False
+SMTP_SSL = {{ galera_notify_smtp_ssl | default('False') }}
 
 # Set to True if you need to authenticate to your SMTP server
 SMTP_AUTH = {{ galera_notify_smtp_auth }}
@@ -46,6 +47,8 @@ SMTP_PASSWORD = '{{ galera_notify_smtp_password }}'
 # Takes a single sender
 MAIL_FROM = '{{ galera_notify_mail_from }}'
 # Takes a list of recipients
+# Need Date in Header for SMTP RFC Compliance
+DATE = email.utils.formatdate()
 MAIL_TO = ['{{ galera_notify_mail_to }}']
 
 # Edit below at your own risk
@@ -86,8 +89,8 @@ def main(argv):
             elif opt in ("--index"):
                 message_obj.set_index(arg)
         try:
-            send_notification(MAIL_FROM, MAIL_TO, 'Galera Notification: ' + THIS_SERVER,
-                              str(message_obj), mariadb_smtp_server, SMTP_PORT, SMTP_SSL, SMTP_AUTH,
+            send_notification(MAIL_FROM, MAIL_TO, 'Galera Notification: ' + THIS_SERVER, DATE,
+                              str(message_obj), SMTP_SERVER, SMTP_PORT, SMTP_SSL, SMTP_AUTH,
                               SMTP_USERNAME, SMTP_PASSWORD)
         except Exception, e:
             print "Unable to send notification: %s" % e
@@ -98,18 +101,19 @@ def main(argv):
 
     sys.exit(0)
 
-def send_notification(from_email, to_email, subject, message, mariadb_smtp_server,
+def send_notification(from_email, to_email, subject, date, message, smtp_server,
                       smtp_port, use_ssl, use_auth, smtp_user, smtp_pass):
     msg = MIMEText(message)
 
     msg['From'] = from_email
     msg['To'] = ', '.join(to_email)
     msg['Subject'] =  subject
+    msg['Date'] =  date
 
     if(use_ssl):
-        mailer = smtplib.SMTP_SSL(mariadb_smtp_server, smtp_port)
+        mailer = smtplib.SMTP_SSL(smtp_server, smtp_port)
     else:
-        mailer = smtplib.SMTP(mariadb_smtp_server, smtp_port)
+        mailer = smtplib.SMTP(smtp_server, smtp_port)
 
     if(use_auth):
         mailer.login(smtp_user, smtp_pass)

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -36,7 +36,7 @@ SMTP_SERVER = '{{ galera_notify_smtp_server }}'
 SMTP_PORT = {{ galera_notify_smtp_port }}
 
 # Set to True if you need SMTP over SSL
-SMTP_SSL = {{ galera_notify_smtp_ssl | default('False') }}
+SMTP_SSL = {{ galera_notify_smtp_ssl }}
 
 # Set to True if you need to authenticate to your SMTP server
 SMTP_AUTH = {{ galera_notify_smtp_auth }}

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -109,6 +109,7 @@ def send_notification(from_email, to_email, subject, date, message, smtp_server,
     msg['To'] = ', '.join(to_email)
     msg['Subject'] =  subject
     msg['Date'] =  date
+    msg['Message-ID'] = email.utils.make_msgid()
 
     if(use_ssl):
         mailer = smtplib.SMTP_SSL(smtp_server, smtp_port)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
* Use the lastest version of galera notify ( from https://github.com/gguillen/galeranotify )
bump version from 1.3 to 1.5
* Some mail server refuse mails if they don't have a Message-ID header (like the sympa mailing list)
simple fix with : `msg['Message-ID'] = email.utils.make_msgid()`
* Add the possiblity to use ssl over SMTP

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
