### PR TITLE
sync config files

### DIFF
--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -1,15 +1,14 @@
-#
-# These groups are read by MariaDB server.
-# Use it for options that only the server (but not clients) should see
-#
-# See the examples of server my.cnf files in /usr/share/mysql/
-#
-
-# this is read by the standalone daemon and embedded servers
-[server]
-
-# this is only for the mysqld standalone daemon
 [mysqld]
+binlog_format=ROW
+default_storage_engine=InnoDB
+innodb_autoinc_lock_mode=2
+query_cache_size=0
+query_cache_type=0
+
+#
+# Allow server to accept connections on this interface
+#
+bind-address={{ mariadb_bind_address }}
 
 {% if mariadb_charset_server | default('auto') != 'auto' %}
 character-set-server  = {{ mariadb_charset_server }}
@@ -44,12 +43,9 @@ ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name 
 ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}
 
-#
-# * Galera-related settings
-#
 [galera]
-# Mandatory settings
 wsrep_on=ON
+wsrep_node_name={{ ansible_hostname }}
 wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
@@ -65,20 +61,15 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+{% if galera_use_gmcast_segment and ('galera_gmcast_segment' in hostvars[inventory_hostname]) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[inventory_hostname]['galera_gmcast_segment'] | int }}"
+{% endif %}
+
 wsrep_sst_method={{ galera_sst_method }}
 {% if galera_sst_method == 'mariabackup' %}
 wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% endif %}
 
-binlog_format=row
-default_storage_engine=InnoDB
-innodb_autoinc_lock_mode=2
-#
-# Allow server to accept connections on all interfaces.
-#
-bind-address={{ mariadb_bind_address }}
-#
-# Optional setting
 {% if galera_wsrep_slave_threads == "auto" %}
 wsrep_slave_threads={{ 1 if (ansible_processor_vcpus <= 1) else (ansible_processor_vcpus - 1) }}
 {% else %}
@@ -90,22 +81,17 @@ wsrep_slave_threads={{ galera_wsrep_slave_threads }}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
+wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
+wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"
+wsrep_node_address="{{ galera_wsrep_node_address }}"
+
+{% if galera_extra_wsrep_provider_options is defined %}
+wsrep_provider_options = "{% for item in galera_extra_wsrep_provider_options %}{% set _key = item.split(': ')[0] %}{% set _val = galera_extra_wsrep_provider_options[_key] %}{{ _key }} = {{ _val }}{% if not loop.last %}; {% endif %}{% endfor %}"
+{% endif %}
+
 [sst]
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
 encrypt=3
 tcert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
 tkey = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}
-
-# this is only for embedded server
-[embedded]
-
-# This group is only read by MariaDB servers, not by MySQL.
-# If you use the same .cnf file for MySQL and MariaDB,
-# you can put MariaDB-only options here
-[mariadb]
-
-# This group is only read by MariaDB-10.1 servers.
-# If you use the same .cnf file for MariaDB of different versions,
-# use this group for options that older servers don't understand
-[mariadb-10.1]

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -1,15 +1,14 @@
-#
-# These groups are read by MariaDB server.
-# Use it for options that only the server (but not clients) should see
-#
-# See the examples of server my.cnf files in /usr/share/mysql/
-#
-
-# this is read by the standalone daemon and embedded servers
-[server]
-
-# this is only for the mysqld standalone daemon
 [mysqld]
+binlog_format=ROW
+default_storage_engine=InnoDB
+innodb_autoinc_lock_mode=2
+query_cache_size=0
+query_cache_type=0
+
+#
+# Allow server to accept connections on this interface
+#
+bind-address={{ mariadb_bind_address }}
 
 {% if mariadb_charset_server | default('auto') != 'auto' %}
 character-set-server  = {{ mariadb_charset_server }}
@@ -44,12 +43,9 @@ ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name 
 ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}
 
-#
-# * Galera-related settings
-#
 [galera]
-# Mandatory settings
 wsrep_on=ON
+wsrep_node_name={{ ansible_hostname }}
 wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
@@ -65,20 +61,15 @@ wsrep_cluster_address="gcomm://"
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+{% if galera_use_gmcast_segment and ('galera_gmcast_segment' in hostvars[inventory_hostname]) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[inventory_hostname]['galera_gmcast_segment'] | int }}"
+{% endif %}
+
 wsrep_sst_method={{ galera_sst_method }}
 {% if galera_sst_method == 'mariabackup' %}
 wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% endif %}
 
-binlog_format=row
-default_storage_engine=InnoDB
-innodb_autoinc_lock_mode=2
-#
-# Allow server to accept connections on all interfaces.
-#
-bind-address={{ mariadb_bind_address }}
-#
-# Optional setting
 {% if galera_wsrep_slave_threads == "auto" %}
 wsrep_slave_threads={{ 1 if (ansible_processor_vcpus <= 1) else (ansible_processor_vcpus - 1) }}
 {% else %}
@@ -90,22 +81,17 @@ wsrep_slave_threads={{ galera_wsrep_slave_threads }}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
+wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
+wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"
+wsrep_node_address="{{ galera_wsrep_node_address }}"
+
+{% if galera_extra_wsrep_provider_options is defined %}
+wsrep_provider_options = "{% for item in galera_extra_wsrep_provider_options %}{% set _key = item.split(': ')[0] %}{% set _val = galera_extra_wsrep_provider_options[_key] %}{{ _key }} = {{ _val }}{% if not loop.last %}; {% endif %}{% endfor %}"
+{% endif %}
+
 [sst]
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}
 encrypt=3
 tcert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
 tkey = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
 {% endif %}
-
-# this is only for embedded server
-[embedded]
-
-# This group is only read by MariaDB servers, not by MySQL.
-# If you use the same .cnf file for MySQL and MariaDB,
-# you can put MariaDB-only options here
-[mariadb]
-
-# This group is only read by MariaDB-10.1 servers.
-# If you use the same .cnf file for MariaDB of different versions,
-# use this group for options that older servers don't understand
-[mariadb-10.1]

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -1,16 +1,52 @@
 [mysqld]
-#mysql settings
 binlog_format=ROW
-default-storage-engine=innodb
+default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
 query_cache_size=0
 query_cache_type=0
+
+#
+# Allow server to accept connections on this interface
+#
 bind-address={{ mariadb_bind_address }}
+
+{% if mariadb_charset_server | default('auto') != 'auto' %}
+character-set-server  = {{ mariadb_charset_server }}
+init-connect          = 'SET NAMES {{ mariadb_charset_server }}'
+{% endif %}
+{% if mariadb_collation_server | default('auto') != 'auto' %}
+collation-server      = {{ mariadb_collation_server }}
+{% endif %}
+
+{% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
+innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
+{% endif %}
+{% if mariadb_innodb_write_io_threads | default('auto') != "auto" %}
+innodb_write_io_threads = {{ mariadb_innodb_write_io_threads }}
+{% endif %}
+{% if mariadb_max_connections | default('auto') != "auto" %}
+max_connections = {{ mariadb_max_connections }}
+{% endif %}
+{% if mariadb_slow_query_log_enabled %}
+slow_query_log
+{% endif %}
+{% if mariadb_long_query_time | default('auto') != "auto" %}
+long_query_time = {{ mariadb_long_query_time }}
+{% endif %}
+
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 %}
+ssl_ca = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}
+ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
+{% endif %}
 
 [galera]
 wsrep_on=ON
 wsrep_node_name={{ ansible_hostname }}
-wsrep_provider="{{ galera_wsrep_provider }}"
+wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
 {% for node in galera_cluster_nodes %}
@@ -25,18 +61,26 @@ wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ipw
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+{% if galera_use_gmcast_segment and ('galera_gmcast_segment' in hostvars[inventory_hostname]) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[inventory_hostname]['galera_gmcast_segment'] | int }}"
+{% endif %}
+
 wsrep_sst_method={{ galera_sst_method }}
 {% if galera_sst_method == 'mariabackup' %}
 wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% endif %}
 
+{% if galera_wsrep_slave_threads == "auto" %}
+wsrep_slave_threads={{ 1 if (ansible_processor_vcpus <= 1) else (ansible_processor_vcpus - 1) }}
+{% else %}
+wsrep_slave_threads={{ galera_wsrep_slave_threads }}
+{% endif %}
+#innodb_flush_log_at_trx_commit=0
+
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
-{% if galera_use_gmcast_segment and (hostvars[inventory_hostname]['galera_gmcast_segment'] is defined) %}
-wsrep_provider_options="gmcast.segment={{ hostvars[inventory_hostname]['galera_gmcast_segment'] | int }}"
-{% endif %}
 wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
 wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"
 wsrep_node_address="{{ galera_wsrep_node_address }}"

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -1,16 +1,52 @@
 [mysqld]
-#mysql settings
 binlog_format=ROW
-default-storage-engine=innodb
+default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
 query_cache_size=0
 query_cache_type=0
+
+#
+# Allow server to accept connections on this interface
+#
 bind-address={{ mariadb_bind_address }}
+
+{% if mariadb_charset_server | default('auto') != 'auto' %}
+character-set-server  = {{ mariadb_charset_server }}
+init-connect          = 'SET NAMES {{ mariadb_charset_server }}'
+{% endif %}
+{% if mariadb_collation_server | default('auto') != 'auto' %}
+collation-server      = {{ mariadb_collation_server }}
+{% endif %}
+
+{% if mariadb_innodb_buffer_pool_size | default('auto') != "auto" %}
+innodb_buffer_pool_size = {{ mariadb_innodb_buffer_pool_size }}
+{% endif %}
+{% if mariadb_innodb_read_io_threads | default('auto') != "auto" %}
+innodb_read_io_threads = {{ mariadb_innodb_read_io_threads }}
+{% endif %}
+{% if mariadb_innodb_write_io_threads | default('auto') != "auto" %}
+innodb_write_io_threads = {{ mariadb_innodb_write_io_threads }}
+{% endif %}
+{% if mariadb_max_connections | default('auto') != "auto" %}
+max_connections = {{ mariadb_max_connections }}
+{% endif %}
+{% if mariadb_slow_query_log_enabled %}
+slow_query_log
+{% endif %}
+{% if mariadb_long_query_time | default('auto') != "auto" %}
+long_query_time = {{ mariadb_long_query_time }}
+{% endif %}
+
+{% if mariadb_tls_files and mariadb_tls_files|length == 3 %}
+ssl_ca = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}
+ssl_cert = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }}
+ssl_key = {{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }}
+{% endif %}
 
 [galera]
 wsrep_on=ON
 wsrep_node_name={{ ansible_hostname }}
-wsrep_provider="{{ galera_wsrep_provider }}"
+wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
 {% for node in galera_cluster_nodes %}
@@ -25,18 +61,26 @@ wsrep_cluster_address="gcomm://"
 wsrep_provider_options="socket.ssl_cert={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_cert.name }};socket.ssl_key={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.server_key.name }};socket.ssl_ca={{ mariadb_certificates_dir }}/{{ mariadb_tls_files.ca_cert.name }}"
 {% endif %}
 
+{% if galera_use_gmcast_segment and ('galera_gmcast_segment' in hostvars[inventory_hostname]) %}
+wsrep_provider_options="gmcast.segment={{ hostvars[inventory_hostname]['galera_gmcast_segment'] | int }}"
+{% endif %}
+
 wsrep_sst_method={{ galera_sst_method }}
 {% if galera_sst_method == 'mariabackup' %}
 wsrep_sst_auth="{{ mariadb_sst_username }}:{{ mariadb_sst_password }}"
 {% endif %}
 
+{% if galera_wsrep_slave_threads == "auto" %}
+wsrep_slave_threads={{ 1 if (ansible_processor_vcpus <= 1) else (ansible_processor_vcpus - 1) }}
+{% else %}
+wsrep_slave_threads={{ galera_wsrep_slave_threads }}
+{% endif %}
+#innodb_flush_log_at_trx_commit=0
+
 {% if galera_enable_galera_monitoring_script %}
 wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name }}'
 {% endif %}
 
-{% if galera_use_gmcast_segment and (hostvars[node]['galera_gmcast_segment'] is defined) %}
-wsrep_provider_options="gmcast.segment={{ hostvars[node]['galera_gmcast_segment'] | int }}"
-{% endif %}
 wsrep_provider_options="ist.recv_addr={{ galera_ist_recv_addr }}:{{ galera_ist_recv_addr_port }}"
 wsrep_provider_options="ist.recv_bind={{ galera_ist_recv_bind }}"
 wsrep_node_address="{{ galera_wsrep_node_address }}"


### PR DESCRIPTION
server.cnf and galera.cnf must be in sync
this ought to be the fist step into morphing this in something more elaborate

## Related Issue
Closes #116 and also extends on fix from @zllovesuki see #115  for more details.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Also started a new cluster in AWS w/ CentOS 8 and it worked ok.
It even set `galera_gmcast_segment` correctly.

@mrlesmithjr, @elcomtik & @zllovesuki - Please take a look!