### PR TITLE
Move user creation to after db creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,11 +44,6 @@
   become: true
   when: inventory_hostname == galera_mysql_first_node
 
-- import_tasks: mysql_users.yml
-  tags:
-    - config
-    - mysql_users
-
 - import_tasks: setup_cluster.yml
   tags:
     - config
@@ -61,6 +56,11 @@
   tags:
     - mysql_databases
   when: mariadb_databases | count > 0
+
+- import_tasks: mysql_users.yml
+  tags:
+    - config
+    - mysql_users
 
 - import_tasks: galera_monitoring.yml
   tags:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Moved the user creation task to after databases have been created to fix issues with users being unable to be created as the table does not yet exist.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/issues/122

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
