### PR TITLE
Enable STARTTLS Support for Galera Monitoring Script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -307,6 +307,8 @@ galera_notify_smtp_password: ""
 galera_notify_smtp_port: 25
 # Set to True if you need SMTP over SSL
 galera_notify_smtp_ssl: False
+# Set to True if you need SMTP over STARTTLS
+galera_notify_smtp_starttls: False
 
 # Defines if cacti monitoring should be enabled for mysql - If used. May remove later.
 galera_enable_cacti_monitoring: false

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -38,6 +38,9 @@ SMTP_PORT = {{ galera_notify_smtp_port }}
 # Set to True if you need SMTP over SSL
 SMTP_SSL = {{ galera_notify_smtp_ssl }}
 
+# Set to True if you need SMTP over TLS
+SMTP_TLS = {{ galera_notify_smtp_tls }}
+
 # Set to True if you need to authenticate to your SMTP server
 SMTP_AUTH = {{ galera_notify_smtp_auth }}
 # Fill in authorization information here if True above
@@ -90,7 +93,7 @@ def main(argv):
                 message_obj.set_index(arg)
         try:
             send_notification(MAIL_FROM, MAIL_TO, 'Galera Notification: ' + THIS_SERVER, DATE,
-                              str(message_obj), SMTP_SERVER, SMTP_PORT, SMTP_SSL, SMTP_AUTH,
+                              str(message_obj), SMTP_SERVER, SMTP_PORT, SMTP_SSL, SMTP_TLS, SMTP_AUTH,
                               SMTP_USERNAME, SMTP_PASSWORD)
         except Exception, e:
             print "Unable to send notification: %s" % e
@@ -102,7 +105,7 @@ def main(argv):
     sys.exit(0)
 
 def send_notification(from_email, to_email, subject, date, message, smtp_server,
-                      smtp_port, use_ssl, use_auth, smtp_user, smtp_pass):
+                      smtp_port, use_ssl, use_tls, use_auth, smtp_user, smtp_pass):
     msg = MIMEText(message)
 
     msg['From'] = from_email
@@ -116,6 +119,9 @@ def send_notification(from_email, to_email, subject, date, message, smtp_server,
     else:
         mailer = smtplib.SMTP(smtp_server, smtp_port)
 
+    if(use_tls):
+        mailer.starttls()
+        
     if(use_auth):
         mailer.login(smtp_user, smtp_pass)
 

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -121,7 +121,7 @@ def send_notification(from_email, to_email, subject, date, message, smtp_server,
 
     if(use_starttls):
         mailer.starttls()
-        
+
     if(use_auth):
         mailer.login(smtp_user, smtp_pass)
 

--- a/templates/etc/mysql/galeranotify.py.j2
+++ b/templates/etc/mysql/galeranotify.py.j2
@@ -39,7 +39,7 @@ SMTP_PORT = {{ galera_notify_smtp_port }}
 SMTP_SSL = {{ galera_notify_smtp_ssl }}
 
 # Set to True if you need SMTP over TLS
-SMTP_TLS = {{ galera_notify_smtp_tls }}
+SMTP_STARTTLS = {{ galera_notify_smtp_starttls }}
 
 # Set to True if you need to authenticate to your SMTP server
 SMTP_AUTH = {{ galera_notify_smtp_auth }}
@@ -93,7 +93,7 @@ def main(argv):
                 message_obj.set_index(arg)
         try:
             send_notification(MAIL_FROM, MAIL_TO, 'Galera Notification: ' + THIS_SERVER, DATE,
-                              str(message_obj), SMTP_SERVER, SMTP_PORT, SMTP_SSL, SMTP_TLS, SMTP_AUTH,
+                              str(message_obj), SMTP_SERVER, SMTP_PORT, SMTP_SSL, SMTP_STARTTLS, SMTP_AUTH,
                               SMTP_USERNAME, SMTP_PASSWORD)
         except Exception, e:
             print "Unable to send notification: %s" % e
@@ -105,7 +105,7 @@ def main(argv):
     sys.exit(0)
 
 def send_notification(from_email, to_email, subject, date, message, smtp_server,
-                      smtp_port, use_ssl, use_tls, use_auth, smtp_user, smtp_pass):
+                      smtp_port, use_ssl, use_starttls, use_auth, smtp_user, smtp_pass):
     msg = MIMEText(message)
 
     msg['From'] = from_email
@@ -119,7 +119,7 @@ def send_notification(from_email, to_email, subject, date, message, smtp_server,
     else:
         mailer = smtplib.SMTP(smtp_server, smtp_port)
 
-    if(use_tls):
+    if(use_starttls):
         mailer.starttls()
         
     if(use_auth):


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
After switching to Microsoft 365, the use of STARTTLS for SMTP is mandatory. In the Galera monitoring script, the use was not yet provided for and I have implemented this and tested it with Microsoft 365.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
