### PR TITLE
reset failed mysql service state 

### DIFF
--- a/tasks/manage_node_state.yml
+++ b/tasks/manage_node_state.yml
@@ -6,6 +6,15 @@
   become: true
   when: inventory_hostname == item
 
+- name: manage_node_state | reset failed status (otherwise service can't be stopped)
+  command: "systemctl reset-failed {{ mariadb_systemd_service_name }}" # noqa command-instead-of-module
+  become: true
+  check_mode: false
+  changed_when: false
+  when:
+    - '"stopped" in mariadb_systemd_service_state'
+    - inventory_hostname == item
+
 - name: manage_node_state | ensure node is fully stopped before continuing
   service: # noqa 503
     name: "{{ mariadb_systemd_service_name }}"


### PR DESCRIPTION
This allows to stop service if it's in failed state. This can happen, for example, if incorrect network configuration was provided during the first role's run and then manual intervention is required.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
