### PR TITLE
update root password without dedicated playbook run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-venv/
+.venv/
 .idea/

--- a/README.md
+++ b/README.md
@@ -40,13 +40,6 @@ None
 
 [Example playbook](./playbook.yml)
 
-## Update the root password
-
-To update a existing mysql root password:
-- Update the variable `mariadb_mysql_root_password`
-- Run a ansible-playbook within tags updating_root_passwords (`--tags updating_root_passwords`)
-- Re-run a ansible-playbook without tags
-
 ## License
 
 MIT

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/centos8/molecule.yml
+++ b/molecule/centos8/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/debian10/molecule.yml
+++ b/molecule/debian10/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/debian11/molecule.yml
+++ b/molecule/debian11/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/debian9/molecule.yml
+++ b/molecule/debian9/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/rocky8/molecule.yml
+++ b/molecule/rocky8/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/rocky9/molecule.yml
+++ b/molecule/rocky9/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/shared/side_effect.yml
+++ b/molecule/shared/side_effect.yml
@@ -1,0 +1,9 @@
+---
+- name: Side effects
+  hosts: all
+  vars:
+    mariadb_mysql_root_password: 'password'
+  tasks:
+    - name: Include ansible-mariadb-galera-cluster
+      include_role:
+        name: ansible-mariadb-galera-cluster

--- a/molecule/ubuntu1604/molecule.yml
+++ b/molecule/ubuntu1604/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/ubuntu2004/molecule.yml
+++ b/molecule/ubuntu2004/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -34,5 +34,6 @@ provisioner:
   playbooks:
     converge: ../shared/converge.yml
     prepare: ../shared/prepare.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: ansible

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -15,8 +15,6 @@
     - "127.0.0.1"
     - "::1"
     - "localhost"
-  tags:
-    - updating_root_passwords
 
 - name: configure_root_access | configuring root my.cnf
   template:
@@ -43,5 +41,3 @@
   with_items:
     - "%"
   when: galera_allow_root_from_any|bool
-  tags:
-    - updating_root_passwords

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -1,15 +1,4 @@
 ---
-- name: configure_root_access | configuring root my.cnf
-  template:
-    src: "root/my.cnf.j2"
-    dest: "/root/.my.cnf"
-    owner: "root"
-    group: "root"
-    mode: "u=rw,g=,o="
-  become: true
-  no_log: true
-  when: ansible_os_family == "RedHat"
-
 - name: configure_root_access | updating root passwords
   mysql_user:
     host: "{{ item }}"
@@ -28,6 +17,16 @@
     - "localhost"
   tags:
     - updating_root_passwords
+
+- name: configure_root_access | configuring root my.cnf
+  template:
+    src: "root/my.cnf.j2"
+    dest: "/root/.my.cnf"
+    owner: "root"
+    group: "root"
+    mode: "u=rw,g=,o="
+  become: true
+  no_log: true
 
 - name: configure_root_access | updating root passwords (allow from anywhere)
   mysql_user:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -60,31 +60,6 @@
   become: true
   when: mariadb_config_overrides is defined
 
-- name: debian | configuring root my.cnf
-  template:
-    src: "root/my.cnf.j2"
-    dest: "/root/.my.cnf"
-    owner: "root"
-    group: "root"
-    mode: "u=rw,g=,o="
-  no_log: true
-  become: true
-
-- name: debian | mysql root password setting
-  debconf:
-    name: "mariadb-server-{{ mariadb_version }}"
-    question: "{{ item.question }}"
-    value: "{{ item.value }}"
-    vtype: "password"
-  become: true
-  changed_when: false
-  no_log: true
-  with_items:
-    - question: "mysql-server/root_password"
-      value: "{{ mariadb_mysql_root_password }}"
-    - question: "mysql-server/root_password_again"
-      value: "{{ mariadb_mysql_root_password }}"
-
 - name: debian | installing mariadb-galera packages
   apt:
     name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"


### PR DESCRIPTION
This change provides the ability to update MySQL root password without special actions. To achieve this, `.my.cnf` for root user should be created just after actual update for any distribution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
