### PR TITLE
chore: access for root user should be allowed from galera bind address

### DIFF
--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -23,6 +23,7 @@
   delay: 5
   with_items:
     - "{{ ansible_hostname }}"
+    - "{{ galera_cluster_bind_address }}"
     - "127.0.0.1"
     - "::1"
     - "localhost"

--- a/tasks/configure_root_access.yml
+++ b/tasks/configure_root_access.yml
@@ -16,6 +16,7 @@
     login_unix_socket: "{{ mariadb_login_unix_socket | default(omit) }}"
     name: "root"
     password: "{{ mariadb_mysql_root_password }}"
+    priv: "*.*:ALL,GRANT"
   become: true
   no_log: true
   run_once: true


### PR DESCRIPTION
it's reasonable to allow access from bind address and helpful when bind interface is not equal to `lo`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
