### PR TITLE
Fix issue #144 : follow link on template module

### DIFF
--- a/tasks/setup_cluster.yml
+++ b/tasks/setup_cluster.yml
@@ -81,6 +81,7 @@
     src: "{{ item }}.j2"
     dest: "/{{ item }}"
     mode: "0644"
+	follow: true
   become: true
   register: "_mariadb_galera_cluster_reconfigured"
   loop: "{{ mariadb_confs }}"

--- a/tasks/setup_cluster.yml
+++ b/tasks/setup_cluster.yml
@@ -81,7 +81,7 @@
     src: "{{ item }}.j2"
     dest: "/{{ item }}"
     mode: "0644"
-	follow: true
+    follow: true
   become: true
   register: "_mariadb_galera_cluster_reconfigured"
   loop: "{{ mariadb_confs }}"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Fix issue #144 : follow link on template module
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
It's fixing the issue #144 , on Debian OS, the file /etc/mysql/my.cnf is a link , so changing the permission is not permitted is `follow: false` on the template module.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#144

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
