### PR TITLE
Missing dependency added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ An [Ansible](https://www.ansible.com) role to install/configure a [MariaDB-Galer
 
 ## Requirements
 
-None
+- Collections:
+  - community.mysql
 
 ## Role Variables
 


### PR DESCRIPTION
There is a dependency of community.mysql (collection), which isn't listed. From my basic understanding of the meta/main.yml file, you can't add collections as dependencies, so I am leaving that as-is.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
