### PR TITLE
Move pre-commit lint check out of matrix jobs

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,6 +11,29 @@ on:
       - main
       - master
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          pip install pre-commit
+      - name: Run pre-commit checks
+        uses: pre-commit/action@v3.0.0
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -56,9 +79,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
           pip install pre-commit
-      - name: Run pre-commit checks
-        run: |
-          SKIP=no-commit-to-branch pre-commit run --all-files
       - name: Test with molecule
         run: |
           molecule test --scenario-name ${{ matrix.molecule_distro }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
+          pip install -r requirements.txt
           pip install pre-commit
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,5 +1,5 @@
 ---
-name: Molecule Test
+name: Verification
 on:
   push:
     branches-ignore:
@@ -12,6 +12,7 @@ on:
       - master
 jobs:
   pre-commit:
+    name: pre-commit Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +35,8 @@ jobs:
           pip install pre-commit
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.0
-  build:
+  molecule:
+    name: Molecule Test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Today, this is run eight times for each part of the matrix of testing that is done with Molecule.  This change makes it a separate job that runs in parallel from the Molecule jobs.

This change also updates the job to use [pre-commit/action](https://github.com/pre-commit/action) and modifies the name of the current job to better reflect what is going on now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
