### PR TITLE
use community.mysql.mysql_user

### DIFF
--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -43,7 +43,7 @@
   when: mariadb_sst_user_plugin == "mysql_native_password"
 
 - name: mysql_users | create MySQL users
-  mysql_user:
+  community.mysql.mysql_user:
     append_privs: "{{ item.0.append_privs | default('no') }}"
     encrypted: "{{ item.0.encrypted | default('no') }}"
     host: "{{ item.1 }}"


### PR DESCRIPTION
to avoid to have unknow plugin option

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
