### PR TITLE
Mariadb version bump and check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,11 @@ mariadb_charset_client: "utf8"
 #   mariadb:
 #     max_connections: 2048
 
+# Defines if mariadb is already available on the target hosts
+# It will compare version between ansible and system and exit early if missmatch
+# This prevent unexpected change on role upgrade
+mariadb_upgrade: false
+
 # Galera settings
 
 # Defines if the galera cluster should be reconfigured

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 # MariaDB setting
 
 # Define mariadb version
-mariadb_version: "10.6"
+mariadb_version: "10.11"
 
 # Defines if we should enable the MariaDB repo or use version within OS repos.
 galera_enable_mariadb_repo: true

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -34,3 +34,40 @@
   tags:
     - install
     - config
+
+- name: Check mariadb_version on target system
+  command: "mariadb -V"
+  check_mode: false
+  register: mariadb_version_check
+  failed_when: '"mariadb" not in mariadb_version_check.stdout and mariadb_version_check.rc == 0'
+  changed_when: not 'mariadb_version_check.rc == 0'
+  when: not mariadb_upgrade|bool
+  tags:
+    - install
+    - config
+
+- name: Extract MariaDB version
+  set_fact:
+    mariadb_version_checked: "{{ mariadb_version_check.stdout.split(' ')[5] }}"
+  check_mode: false
+  when: not mariadb_upgrade|bool and mariadb_version_check.rc == 0
+  tags:
+    - install
+    - config
+
+- name:
+  debug:
+    msg: "Installed {{ mariadb_version_checked }} - mariadb_version: {{ mariadb_version }}"
+  when: not mariadb_upgrade|bool and mariadb_version_check.rc == 0
+
+- name: Verify the expected mariadb_version
+  assert:
+    that: 'mariadb_version_checked.startswith("{{ mariadb_version }}")'
+    fail_msg: >-
+      The mariadb_version "{{ mariadb_version }}" doesn't match the one
+      installed on the system: {{ mariadb_version_checked }}.
+      Use the correct mariadb_version or set mariadb_upgrade: True
+  when: not mariadb_upgrade|bool and mariadb_version_check.rc == 0
+  tags:
+    - install
+    - config

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -1,5 +1,4 @@
 ---
-mariadb_version: "10.11"
 mariadb_login_unix_socket: "/var/run/mysqld/mysqld.sock"
 mariadb_pre_req_packages:
   - "apt-transport-https"


### PR DESCRIPTION
This PR bump the default mariadb_version and implement a preliminary version check.

## Description
- Bumping to 10.11 is the more recent version that work across all current supported releases.
But user should note that using this version is arbitrary, they should carefully mind the right version for their use.
- This un-hardcode the debian-12 specific version
- Implement a version check based on what's installed on target systems.


## Related Issue
Issue raised on PR:
https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/pull/171#issuecomment-1685849535

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
