### PR TITLE
Added support for redhat 8 and 9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ mariadb_version: "10.11"
 # Defines if we should enable the MariaDB repo or use version within OS repos.
 galera_enable_mariadb_repo: true
 
+# Defines if we should enable the epel repo or use version within OS repos.
+galera_enable_epel_repo: true
+
 # Defines repository settings for apt
 mariadb_debian_repo: "deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 mariadb_debian_repo_keyserver: "keyserver.ubuntu.com"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ mariadb_version: "10.11"
 # Defines if we should enable the MariaDB repo or use version within OS repos.
 galera_enable_mariadb_repo: true
 
+# Defines if we should install the epel repo via rpm
+galera_enable_epel_repo: false
+
 # Defines repository settings for apt
 mariadb_debian_repo: "deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 mariadb_debian_repo_keyserver: "keyserver.ubuntu.com"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,9 +9,6 @@ mariadb_version: "10.11"
 # Defines if we should enable the MariaDB repo or use version within OS repos.
 galera_enable_mariadb_repo: true
 
-# Defines if we should enable the epel repo or use version within OS repos.
-galera_enable_epel_repo: true
-
 # Defines repository settings for apt
 mariadb_debian_repo: "deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 mariadb_debian_repo_keyserver: "keyserver.ubuntu.com"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,18 +12,12 @@
   when:
     - galera_enable_mariadb_repo | bool
 
-- name: redhat | adding epel repo
-  yum_repository:
-    name: "epel"
-    file: "epel"
-    description: "epel"
-    metalink: "{{ epel_redhat_repo }}"
-    gpgkey: "{{ epel_redhat_repo_key }}"
-    gpgcheck: true
-  become: true
-  register: "epel_repo_added"
+- name: redhat | Install the epel repo
+  yum:
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+    state: present
   when:
-    - epel_redhat_repo is defined and epel_redhat_repo_key is defined and ansible_distribution_major_version is version('8', '>=')
+    - galera_enable_epel_repo | bool
 
 # fix for conflicting package from appstream
 - name: redhat | disable appstream mysql/mariadb modules

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -23,8 +23,7 @@
   become: true
   register: "epel_repo_added"
   when:
-    - galera_enable_epel_repo | bool
-    - ansible_distribution_major_version is version('8', '>=')
+    - epel_redhat_repo is defined and epel_redhat_repo_key is defined and ansible_distribution_major_version is version('8', '>=')
 
 # fix for conflicting package from appstream
 - name: redhat | disable appstream mysql/mariadb modules

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -12,6 +12,19 @@
   when:
     - galera_enable_mariadb_repo | bool
 
+- name: redhat | adding epel repo
+  yum_repository:
+    name: "epel"
+    file: "epel"
+    description: "epel"
+    metalink: "{{ epel_redhat_repo }}"
+    gpgkey: "{{ epel_redhat_repo_key }}"
+    gpgcheck: true
+  become: true
+  register: "epel_repo_added"
+  when:
+    - ansible_distribution_major_version is version('8', '>=')
+
 # fix for conflicting package from appstream
 - name: redhat | disable appstream mysql/mariadb modules
   command:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -23,6 +23,7 @@
   become: true
   register: "epel_repo_added"
   when:
+    - galera_enable_epel_repo | bool
     - ansible_distribution_major_version is version('8', '>=')
 
 # fix for conflicting package from appstream

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -15,5 +15,4 @@ mariadb_confs:
 mariadb_temp_confs:
   - "etc/my.cnf.d/server.cnf"
 galera_wsrep_provider: "/usr/lib64/galera-4/libgalera_smm.so"
-epel_redhat_repo: "https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir"
-epel_redhat_repo_key: "https://fedoraproject.org/fedora.gpg"
+galera_enable_epel_repo: true

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,0 +1,19 @@
+---
+mariadb_login_unix_socket: "/var/lib/mysql/mysql.sock"
+mariadb_pre_req_packages:
+  - "procps-ng"
+mariadb_packages:
+  - "python3-mysql"
+  - "MariaDB-server"
+  - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
+mariadb_systemd_service_name: "mariadb"
+mariadb_confs:
+  - "etc/my.cnf.d/server.cnf"
+mariadb_temp_confs:
+  - "etc/my.cnf.d/server.cnf"
+galera_wsrep_provider: "/usr/lib64/galera-4/libgalera_smm.so"
+epel_redhat_repo: "https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch&infra=$infra&content=$contentdir"
+epel_redhat_repo_key: "https://fedoraproject.org/fedora.gpg"

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,19 @@
+---
+mariadb_login_unix_socket: "/var/lib/mysql/mysql.sock"
+mariadb_pre_req_packages:
+  - "procps-ng"
+mariadb_packages:
+  - "python3-mysql"
+  - "MariaDB-server"
+  - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
+mariadb_systemd_service_name: "mariadb"
+mariadb_confs:
+  - "etc/my.cnf.d/server.cnf"
+mariadb_temp_confs:
+  - "etc/my.cnf.d/server.cnf"
+galera_wsrep_provider: "/usr/lib64/galera-4/libgalera_smm.so"
+epel_redhat_repo: "https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch&infra=$infra&content=$contentdir"
+epel_redhat_repo_key: "https://fedoraproject.org/fedora.gpg"

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -15,5 +15,4 @@ mariadb_confs:
 mariadb_temp_confs:
   - "etc/my.cnf.d/server.cnf"
 galera_wsrep_provider: "/usr/lib64/galera-4/libgalera_smm.so"
-epel_redhat_repo: "https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch&infra=$infra&content=$contentdir"
-epel_redhat_repo_key: "https://fedoraproject.org/fedora.gpg"
+galera_enable_epel_repo: true


### PR DESCRIPTION
## Description
The process for adding the epel repo is a bit different for redhat. This pull adds an ansible task to add the epel repo for rhel 8 and 9.

## Related Issue
#175 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
