### PR TITLE
skip query cache if it's not set

### DIFF
--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -2,8 +2,6 @@
 binlog_format=ROW
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
-query_cache_size=0
-query_cache_type=0
 
 #
 # Allow server to accept connections on this interface

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -2,8 +2,6 @@
 binlog_format=ROW
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
-query_cache_size=0
-query_cache_type=0
 
 #
 # Allow server to accept connections on this interface

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -2,8 +2,6 @@
 binlog_format=ROW
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
-query_cache_size=0
-query_cache_type=0
 
 #
 # Allow server to accept connections on this interface

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -2,8 +2,6 @@
 binlog_format=ROW
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
-query_cache_size=0
-query_cache_type=0
 
 #
 # Allow server to accept connections on this interface

--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -18,8 +18,12 @@ max_allowed_packet = {{ mariadb_mysql_settings['max_allowed_packet'] }}
 max_binlog_size = {{ mariadb_mysql_settings['max_binlog_size'] }}
 myisam-recover = BACKUP
 port = {{ mariadb_mysql_port }}
+{% if mariadb_mysql_settings['query_cache_limit'] is defined -%}
 query_cache_limit = {{ mariadb_mysql_settings['query_cache_limit'] }}
+{%- endif %}
+{% if mariadb_mysql_settings['query_cache_size'] is defined -%}
 query_cache_size = {{ mariadb_mysql_settings['query_cache_size'] }}
+{%- endif %}
 skip-external-locking
 socket = {{ mariadb_login_unix_socket }}
 thread_cache_size = {{ mariadb_mysql_settings['thread_cache_size'] }}


### PR DESCRIPTION
Template query cache values to be skipped in case they're not provided.

Need to keep them templated as MySQL & MariaDB diverged in behavior (MySQL>=5.7.20 removed QC, MariaDB enabled it by default).

## Related Issue
Closes #184 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
