### PR TITLE
Fix MariaDB Version check/comparing

### DIFF
--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -48,7 +48,7 @@
 
 - name: Extract MariaDB version
   set_fact:
-    mariadb_version_checked: "{{ mariadb_version_check.stdout.split(' ')[5] }}"
+    mariadb_version_checked: "{{ mariadb_version_check.stdout.split(' ')[2] }}"
   check_mode: false
   when: not mariadb_upgrade|bool and mariadb_version_check.rc == 0
   tags:


### PR DESCRIPTION
## Description
Checking and Comparing versions failed because of the output from `mariadb -V` changed in the past it is still broken for 10.x and 11.x.

```
11.x
mariadb -V
mariadb from 11.2.2-MariaDB, client 15.2 for debian-linux-gnu (x86_64) using readline EditLine wrapper
```

```
10.x
mariadb -V
mariadb  Ver 15.1 Distrib 10.11.6-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper
```
This PR fixed the issue for the latest, 11.x MariaDB Version.

In a perfect world there is a need for a version check for the version check?!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
