### PR TITLE
Adding newlines

### DIFF
--- a/templates/etc/mysql/my.cnf.j2
+++ b/templates/etc/mysql/my.cnf.j2
@@ -20,10 +20,10 @@ myisam-recover = BACKUP
 port = {{ mariadb_mysql_port }}
 {% if mariadb_mysql_settings['query_cache_limit'] is defined -%}
 query_cache_limit = {{ mariadb_mysql_settings['query_cache_limit'] }}
-{%- endif %}
+{%+ endif %}
 {% if mariadb_mysql_settings['query_cache_size'] is defined -%}
 query_cache_size = {{ mariadb_mysql_settings['query_cache_size'] }}
-{%- endif %}
+{%+ endif %}
 skip-external-locking
 socket = {{ mariadb_login_unix_socket }}
 thread_cache_size = {{ mariadb_mysql_settings['thread_cache_size'] }}


### PR DESCRIPTION
## Description
It breaks the configuration because of missing newlines:
`query_cache_limit = 1Mquery_cache_size = 16Mskip-external-locking`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
