### PR TITLE
fix remote nodes bind interface lookup

### DIFF
--- a/templates/etc/my.cnf.d/server.cnf.j2
+++ b/templates/etc/my.cnf.d/server.cnf.j2
@@ -48,7 +48,7 @@ wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
 {% for node in galera_cluster_nodes %}
-{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ galera_cluster_bind_interface]['ipv4']['address']) | mandatory ) %}
+{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ hostvars[node]['galera_cluster_bind_interface']|default(galera_cluster_bind_interface)]['ipv4']['address']) | mandatory ) %}
 {% endfor %}
 wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ansible.utils.ipwrap') | list | join(',') }}"
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made

--- a/templates/etc/my.cnf.d/server.cnf.temp.j2
+++ b/templates/etc/my.cnf.d/server.cnf.temp.j2
@@ -48,7 +48,7 @@ wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
 {% for node in galera_cluster_nodes %}
-{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ galera_cluster_bind_interface]['ipv4']['address']) | mandatory ) %}
+{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ hostvars[node]['galera_cluster_bind_interface']|default(galera_cluster_bind_interface)]['ipv4']['address']) | mandatory ) %}
 {% endfor %}
 #wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ansible.utils.ipwrap') | list | join(',') }}"
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -48,7 +48,7 @@ wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
 {% for node in galera_cluster_nodes %}
-{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ galera_cluster_bind_interface]['ipv4']['address']) | mandatory ) %}
+{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ hostvars[node]['galera_cluster_bind_interface']|default(galera_cluster_bind_interface)]['ipv4']['address']) | mandatory ) %}
 {% endfor %}
 wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ansible.utils.ipwrap') | list | join(',') }}"
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made

--- a/templates/etc/mysql/conf.d/galera.cnf.temp.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.temp.j2
@@ -48,7 +48,7 @@ wsrep_provider={{ galera_wsrep_provider }}
 wsrep_cluster_name="{{ galera_cluster_name }}"
 {% set _galera_cluster_node_addresses = [] %}
 {% for node in galera_cluster_nodes %}
-{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ galera_cluster_bind_interface]['ipv4']['address']) | mandatory ) %}
+{%   set _ = _galera_cluster_node_addresses.append( hostvars[node]['galera_cluster_bind_address'] | default(hostvars[node]['ansible_' ~ hostvars[node]['galera_cluster_bind_interface']|default(galera_cluster_bind_interface)]['ipv4']['address']) | mandatory ) %}
 {% endfor %}
 #wsrep_cluster_address="{{ 'gcomm://' ~ _galera_cluster_node_addresses | map('ansible.utils.ipwrap') | list | join(',') }}"
 # To start failed cluster comment out above and uncomment below...Once cluster is started revert changes and restart mysql on main node where change was made


### PR DESCRIPTION
## Description
When iterating, lookup `galera_cluster_bind_interface` variable value from the inventory of the considered node, instead of the inventory of the node running the task.
This was already done for `galera_cluster_bind_address` variable, this PR do the same for `galera_cluster_bind_interface` variable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
