### PR TITLE
feat: :lock: Allow to define own repo pin priority

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ galera_enable_mariadb_repo: true
 mariadb_debian_repo: "deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 mariadb_debian_repo_keyserver: "keyserver.ubuntu.com"
 mariadb_debian_repo_pin: "nyc2.mirrors.digitalocean.com"
+mariadb_debian_repo_pin_priority: 600
 
 # Defines repository settings for rpm
 mariadb_redhat_repo: "https://yum.mariadb.org/{{ mariadb_version }}/{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}-amd64"

--- a/templates/etc/apt/preferences.d/mariadb.j2
+++ b/templates/etc/apt/preferences.d/mariadb.j2
@@ -1,3 +1,3 @@
 Package: mariadb-*
 Pin: origin {{ mariadb_debian_repo_pin }}
-Pin-Priority: 600
+Pin-Priority: {{ mariadb_debian_repo_pin_priority }}


### PR DESCRIPTION
Allow to define own repo pin priority

## Description
This feature allow to define own repo pin priority. Some linux distros use own repo with very high value (900 in Astra Linux for example) that breaks proper install of `mariadb-server` package.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
