### PR TITLE
Use RegExp to detect installed MariaDB version

### DIFF
--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -48,7 +48,7 @@
 
 - name: Extract MariaDB version
   set_fact:
-    mariadb_version_checked: "{{ mariadb_version_check.stdout.split(' ')[5] }}"
+    mariadb_version_checked: "{{ mariadb_version_check | regex_search('\\d+\\.\\d+\\.\\d+-MariaDB') }}"
   check_mode: false
   when: not mariadb_upgrade|bool and mariadb_version_check.rc == 0
   tags:

--- a/tasks/setup_cluster.yml
+++ b/tasks/setup_cluster.yml
@@ -124,7 +124,7 @@
   when: >
     not galera_cluster_configured.stat.exists
 
-- name: setup_cluster | custer bootstrap - killing lingering mysql processes to ensure mysql is stopped
+- name: setup_cluster | cluster bootstrap - killing lingering mysql processes to ensure mysql is stopped
   ansible.builtin.command: "pkill {{ mariadb_systemd_service_name }}" # noqa ignore-errors
   become: true
   ignore_errors: true


### PR DESCRIPTION
See the issue linked below for all related background information.

I figured out a regular expression that works for both of the example outputs I have outlined in the issue; it assumes that there's always a `-MariaDB` at the end of a substring that has the version number right in front of it.

I have only tested this with my setup, which is MariaDB 11.4 on Debian 12.

## Related Issue
Fixes https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/issues/222

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

