### PR TITLE
Allow to upgrade packages when allowed by mariadb_upgrade

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -58,8 +58,4 @@
   become: true
   when: mariadb_config_overrides is defined
 
-- name: debian | installing mariadb-galera packages
-  ansible.builtin.apt:
-    name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
-    state: "present"
-  become: true
+- ansible.builtin.import_tasks: mariadb_packages_install.yml

--- a/tasks/mariadb_packages_install.yml
+++ b/tasks/mariadb_packages_install.yml
@@ -1,0 +1,8 @@
+---
+- name: mariadb_packages_install | installing mariadb-galera packages
+  ansible.builtin.package:
+    name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
+    state: "{{ mariadb_upgrade | ternary( 'latest', 'present' ) }}"
+    update_cache: true
+  become: true
+

--- a/tasks/mariadb_packages_install.yml
+++ b/tasks/mariadb_packages_install.yml
@@ -5,4 +5,3 @@
     state: "{{ mariadb_upgrade | ternary( 'latest', 'present' ) }}"
     update_cache: true
   become: true
-

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -59,7 +59,7 @@
 - name: redhat | installing mariadb mysql
   ansible.builtin.yum:
     name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
-    state: "present"
+    state: "{{ mariadb_upgrade | ternary( 'latest', 'present' ) }}"
     update_cache: true
   become: true
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -56,12 +56,7 @@
   become: true
   when: mariadb_config_overrides is defined
 
-- name: redhat | installing mariadb mysql
-  ansible.builtin.yum:
-    name: "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_packages | union( mariabackup_packages ), mariadb_packages ) }}"
-    state: "{{ mariadb_upgrade | ternary( 'latest', 'present' ) }}"
-    update_cache: true
-  become: true
+- ansible.builtin.import_tasks: mariadb_packages_install.yml
 
 - name: redhat | remove migrated-from-my.cnf-settings.conf that is causing MariaDB to not start
   ansible.builtin.file:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Allow upgrading packages when allowed by mariadb_upgrade

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
I observed that when I wanted to upgrade from old MariaDB 10.6 to the current default 10.11, not even setting mariadb_upgrade=True was sufficient to upgrade packages when they were already installed on my system. 

So I introduced logic, which allows to update packages when the user wants to upgrade. 

This is potentionally dangerous and testing is advised for any upgrades on the production database.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
