### PR TITLE
Templating: Only use wsrep_provider_options when galera_extra_wsrep_p…

### DIFF
--- a/tasks/setup_cluster.yml
+++ b/tasks/setup_cluster.yml
@@ -48,7 +48,7 @@
         galera_extra_wsrep_provider_options: >
           {{
             galera_extra_wsrep_provider_options | combine({
-              'ist.recv_addr': galera_ist_recv_addr + ":" + galera_ist_recv_addr_port,
+              'ist.recv_addr': galera_ist_recv_addr + ":" + galera_ist_recv_addr_port|string,
               'ist.recv_bind': galera_ist_recv_bind
               })
           }}

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -72,7 +72,9 @@ wsrep_notify_cmd='{{ galera_monitor_script_path }}/{{ galera_monitor_script_name
 
 wsrep_node_address="{{ galera_wsrep_node_address }}"
 
+{% if galera_extra_wsrep_provider_options is defined %}
 wsrep_provider_options = "{% for item in galera_extra_wsrep_provider_options %}{% set _key = item.split(': ')[0] %}{% set _val = galera_extra_wsrep_provider_options[_key] %}{{ _key }} = {{ _val }}{% if not loop.last %}; {% endif %}{% endfor %}"
+{% endif %}
 
 [sst]
 {% if mariadb_tls_files and mariadb_tls_files|length == 3 and galera_sst_tls_enabled  %}


### PR DESCRIPTION
…rovider_options is defined

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Only use wsrep_provider_options when galera_extra_wsrep_provider_options is defined :)

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly. (No change required)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
