### PR TITLE
Bug fix: Only reset a failed state if present to avoid error

### DIFF
--- a/tasks/manage_node_state.yml
+++ b/tasks/manage_node_state.yml
@@ -6,6 +6,9 @@
   become: true
   when: inventory_hostname == item
 
+- name: manage_node_state | Populate service facts
+  ansible.builtin.service_facts:
+
 - name: manage_node_state | reset failed status (otherwise service can't be stopped)
   command: "systemctl reset-failed {{ mariadb_systemd_service_name }}" # noqa command-instead-of-module
   become: true
@@ -14,6 +17,7 @@
   when:
     - '"stopped" in mariadb_systemd_service_state'
     - inventory_hostname == item
+    - '"failed" in ansible_facts.services[mariadb_systemd_service_name].state'
 
 - name: manage_node_state | ensure node is fully stopped before continuing
   ansible.builtin.service:

--- a/vars/almalinux-8.yml
+++ b/vars/almalinux-8.yml
@@ -10,7 +10,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/almalinux-9.yml
+++ b/vars/almalinux-9.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -10,7 +10,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/centos-9.yml
+++ b/vars/centos-9.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/debian-11.yml
+++ b/vars/debian-11.yml
@@ -12,7 +12,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/mysql/debian.cnf"
     mode: "0600"

--- a/vars/debian-12.yml
+++ b/vars/debian-12.yml
@@ -12,7 +12,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/mysql/debian.cnf"
     mode: "0600"

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -13,7 +13,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mysql"
+mariadb_systemd_service_name: "mysql.service"
 mariadb_confs:
   - name: "etc/mysql/debian.cnf"
     mode: "0600"

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -8,7 +8,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -8,7 +8,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mysql"
+mariadb_systemd_service_name: "mysql.service"
 mariadb_confs:
   - name: "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/rocky-8.yml
+++ b/vars/rocky-8.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/rocky-9.yml
+++ b/vars/rocky-9.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "MariaDB-backup"
 mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/my.cnf.d/server.cnf"
 mariadb_temp_confs:

--- a/vars/ubuntu-20.yml
+++ b/vars/ubuntu-20.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/mysql/debian.cnf"
   - name: "etc/mysql/my.cnf"

--- a/vars/ubuntu-22.yml
+++ b/vars/ubuntu-22.yml
@@ -11,7 +11,7 @@ mariadb_packages:
 mariabackup_packages:
   - "mariadb-backup"
 mariadb_certificates_dir: "/etc/mysql/certificates"
-mariadb_systemd_service_name: "mariadb"
+mariadb_systemd_service_name: "mariadb.service"
 mariadb_confs:
   - name: "etc/mysql/debian.cnf"
   - name: "etc/mysql/my.cnf"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Fixes an issue where a failed state is reset while none is present, leading to an error and the playbook failing:

```
  TASK [ansible-mariadb-galera-cluster : manage_node_state | reset failed status (otherwise service can't be stopped)] ***
  fatal: [node2]: FAILED! => {"changed": false, "cmd": ["systemctl", "reset-failed", "mariadb"], "delta": "0:00:00.007486", "end": "2024-11-14 11:43:51.597408", "msg": "non-zero return code", "rc": 1, "start": "2024-11-14 11:43:51.589922", "stderr": "Failed to reset failed state of unit mariadb.service: Unit mariadb.service not loaded.", "stderr_lines": ["Failed to reset failed state of unit mariadb.service: Unit mariadb.service not loaded."], "stdout": "", "stdout_lines": []}
  skipping: [node1]
```

This change ensures a failed state is only reset if it is present and will fix the merge request pipeline for https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/pull/227, https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/pull/229 and https://github.com/mrlesmithjr/ansible-mariadb-galera-cluster/pull/230

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [] I have updated the documentation accordingly. -> No change required.
- [] I have added tests to cover my changes. -> Nothing new required.
- [x] All new and existing tests passed.
