### PR TITLE
Fix clean install to nonstandard datadir

### DIFF
--- a/tasks/custom_datadir_populate.yml
+++ b/tasks/custom_datadir_populate.yml
@@ -1,0 +1,22 @@
+---
+- name: ensure database directory exists
+  ansible.builtin.file:
+    path: "{{ mariadb_mysql_settings.datadir }}"
+    state: directory
+    owner: mysql
+    group: mysql
+    mode: '0755'
+
+- name: check if datadir folder is empty before proceeding
+  find:
+    paths: '/var/lib/mysql/'
+  register: filesFoundInGaleraDatadir
+
+- name: copy default files from default folder to custom datadir (if needed)
+  ansible.builtin.copy:
+    src:  /var/lib/mysql/*
+    dest: "{{ mariadb_mysql_settings.datadir }}"
+    owner: mysql
+    group: mysql
+    mode: '0755'
+  when: filesFoundInGaleraDatadir.matched == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,11 @@
 - ansible.builtin.import_tasks: system_performance_tuning.yml
   tags:
     - config
-
+    
+- ansible.builtin.import_tasks: custom_datadir_populate.yml
+  tags:
+    - always
+    
 - name: flush handlers before continuing
   meta: flush_handlers
   tags:


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
I've created a small check if custom datadir exists and is empty. If it is, default files from /var/lib/mysql will be copied there.
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
This is my fix to the #27, that seems to be fixed for updates, but not for fresh installs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.  - Sorry, I'm having problems with this step. 
- [ ] I have updated the documentation accordingly. - No need, change is a bugfix
- [ ] I have added tests to cover my changes. 
- [ ] All new and existing tests passed.  - Sorry, I'm having problems with this step. `ERROR! the role 'ansible-mariadb-galera-cluster' was not found`