### PR TITLE
fixing an issue with ubuntu 24

### DIFF
--- a/vars/ubuntu-24.yml
+++ b/vars/ubuntu-24.yml
@@ -1,0 +1,21 @@
+---
+mariadb_login_unix_socket: "/var/run/mysqld/mysqld.sock"
+mariadb_pre_req_packages:
+  - "apt-transport-https"
+  - "software-properties-common"
+  - "python3-pymysql"
+  - "rsync"
+mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
+mariadb_packages:
+  - "mariadb-server"
+mariabackup_packages:
+  - "mariadb-backup"
+mariadb_certificates_dir: "/etc/mysql/certificates"
+mariadb_systemd_service_name: "mariadb.service"
+mariadb_confs:
+  - name: "etc/mysql/debian.cnf"
+  - name: "etc/mysql/my.cnf"
+  - name: "etc/mysql/conf.d/galera.cnf"
+mariadb_temp_confs:
+  - "etc/mysql/conf.d/galera.cnf"
+galera_wsrep_provider: "/usr/lib/galera/libgalera_smm.so"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Installation on Ubuntun 24.04 & 24.11 fails due to the package python-pymysql not exists.
fatal: [XXX]: FAILED! => {"changed": false, "msg": "No package matching 'python-pymysql' is available"}

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
[#239]

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass. (tested on local ubuntu 24.04 environment)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
