### PR TITLE
Fix user creation for multiple cluster deployments

### DIFF
--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -14,9 +14,7 @@
           The plugin for mariadb_sst_username was
           set to unix_socket but the user does not exist.
       when: mariadb_sst_username__found.failed
-  delegate_to: "{{ galera_mysql_first_node }}"
-  run_once: true
-  when: mariadb_sst_user_plugin == "unix_socket"
+  when: (mariadb_sst_user_plugin == "unix_socket") and (ansible_hostname in galera_mysql_first_node)
 
 - name: Create definition for mariadb_sst_user via unix_socket
   ansible.builtin.set_fact:
@@ -26,9 +24,7 @@
           - 'localhost'
         plugin: "{{ mariadb_sst_user_plugin }}"
         priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
-  delegate_to: "{{ galera_mysql_first_node }}"
-  run_once: true
-  when: mariadb_sst_user_plugin == "unix_socket"
+  when: (mariadb_sst_user_plugin == "unix_socket") and (ansible_hostname in galera_mysql_first_node)
 
 - name: Create definition for mariadb_sst_user via mysql_native_password
   ansible.builtin.set_fact:
@@ -38,9 +34,7 @@
           - 'localhost'
         password: "{{ mariadb_sst_password }}"
         priv: "*.*:RELOAD,PROCESS,LOCK TABLES,BINLOG MONITOR"
-  delegate_to: "{{ galera_mysql_first_node }}"
-  run_once: true
-  when: mariadb_sst_user_plugin == "mysql_native_password"
+  when: (mariadb_sst_user_plugin == "mysql_native_password") and (ansible_hostname in galera_mysql_first_node)
 
 - name: mysql_users | create MySQL users
   community.mysql.mysql_user:
@@ -58,8 +52,7 @@
     state: "{{ item.0.state | default('present') }}"
   become: true
   no_log: true
-  delegate_to: "{{ galera_mysql_first_node }}"
-  run_once: true
+  when: ansible_hostname in galera_mysql_first_node
   with_subelements:
     - "{{ (galera_sst_method == 'mariabackup') | ternary( mariadb_mysql_users | union( mariadb_sst_user ), mariadb_mysql_users ) }}"
     - "hosts"


### PR DESCRIPTION
## Description
When provisioning multiple clusters from a single playbook, the user creation step currently runs only for one cluster.
These changes ensure that user creation is executed for each cluster.

### Example playbook:
```
- name: install galera cluster
  hosts: galera_cluster
  become: true
  roles:
    - mariadb_galera
```
### Example inventory:

```
cluster-1-host-1 ansible_ssh_host=192.168.1.1
cluster-1-host-2 ansible_ssh_host=192.168.1.2
cluster-1-host-3 ansible_ssh_host=192.168.1.3

cluster-2-host-1 ansible_ssh_host=192.168.2.1
cluster-2-host-2 ansible_ssh_host=192.168.2.2
cluster-2-host-3 ansible_ssh_host=192.168.2.3


[galera_cluster_1]
cluster-1-host-1
cluster-1-host-2
cluster-1-host-3

[galera_cluster_1:vars]
galera_cluster_nodes_group=galera_cluster_1

[galera_cluster_2]
cluster-2-host-1
cluster-2-host-2
cluster-2-host-3

[galera_cluster_2:vars]
galera_cluster_nodes_group=galera_cluster_2

[galera_cluster:child]
galera_cluster_1
galera_cluster_2

```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
