### PR TITLE
Add configurable no_log to user creation

### DIFF
--- a/tasks/mysql_users.yml
+++ b/tasks/mysql_users.yml
@@ -57,7 +57,7 @@
     priv: "{{ item.0.priv | default('*.*:USAGE') }}"
     state: "{{ item.0.state | default('present') }}"
   become: true
-  no_log: "{{ galera_users_no_log | bool }}"
+  no_log: "{{ galera_users_no_log | bool | default(true) }}"
   delegate_to: "{{ galera_mysql_first_node }}"
   run_once: true
   with_subelements:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Extends 'galera_users_no_log' from only root user to also include other users.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
