### PR TITLE
Add redhat 9 vars file

### DIFF
--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,16 @@
+---
+mariadb_login_unix_socket: "/var/lib/mysql/mysql.sock"
+mariadb_pre_req_packages:
+  - "python3-mysqlclient"
+mariadb_packages:
+  - "MariaDB-server"
+  - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
+mariadb_systemd_service_name: "mysql.service"
+mariadb_confs:
+  - name: "etc/my.cnf.d/server.cnf"
+mariadb_temp_confs:
+  - "etc/my.cnf.d/server.cnf"
+galera_wsrep_provider: "/usr/lib64/galera-4/libgalera_smm.so"


### PR DESCRIPTION
Addresses the change for mariadb_pre_req_packages from "MySQL-python" to "python3-mysqlclient"

<!--- Provide a short summary of your changes in the Title above -->
Provide a new vars file for RHEL 9 with working package.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The package in the vars/redhat.yml is not working for RHEL 9 ; python 3 uses the python3-mysqlclient, so updating the 
mariadb_pre_req_packages:  from "MySQL-python" to  "python3-mysqlclient" solves the issue.

Here is the error I am getting on RHEL 9.6 : 
```
TASK [mrlesmithjr.mariadb_galera_cluster : redhat | installing pre-reqs] **************************************************************************************************************
fatal: [test-db1]: FAILED! => {"changed": false, "failures": ["No package MySQL-python available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I am not familiar with molecule and I do not see a scenario for redhat ; I have run fedora molecule test to ensure at least one test is working and it appears to do so. I am open to add tests if you think they are required.
