### PR TITLE
make galera_cluster_nodes compatible with ansible >= 2.19 

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,4 @@
 ---
 # vars file for ansible-mariadb-galera-cluster
 
-galera_cluster_nodes: "\
-  {% set _galera_cluster_nodes = [] %}\
-  {% for host in groups[ galera_cluster_nodes_group ] %}\
-  {{   _galera_cluster_nodes.append( host )|default('', True) }}\
-  {% endfor %}\
-  {{ _galera_cluster_nodes }}"
+galera_cluster_nodes: "{{ groups[galera_cluster_nodes_group] | list }}"


### PR DESCRIPTION
## Description
Since upgrading to Ansible 2.19 (Jinja2 3.1+), the variable galera_cluster_nodes is rendered as a string instead of a list. This breaks templates that expect a list (e.g., building wsrep_cluster_address), because lookups iterate over characters of the string rather than hosts.

## Related Issue
#265

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly. (not required)
- [ ] I have added tests to cover my changes. (not required)
- [X] All new and existing tests passed.
