### PR TITLE
DBP-1813-MariaDB Galera Repository No Longer Provides a Release Fil

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,9 +10,9 @@ mariadb_version: "10.11"
 galera_enable_mariadb_repo: true
 
 # Defines repository settings for apt
-mariadb_debian_repo: "deb [arch=amd64,arm64,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
+mariadb_debian_repo: "deb [arch=amd64,arm64,ppc64el] https://mirror.mariadb.org/repo/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 mariadb_debian_repo_keyserver: "keyserver.ubuntu.com"
-mariadb_debian_repo_pin: "nyc2.mirrors.digitalocean.com"
+mariadb_debian_repo_pin: "mirror.mariadb.org"
 mariadb_debian_repo_pin_priority: 600
 
 # Defines repository settings for rpm


### PR DESCRIPTION
During the deployment of the MariaDB Galera cluster via Ansible, the task mariadb_packages_install fails.
The configured repository:

http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.11/ubuntu jammy

no longer provides a valid Release file.
Because of this, apt blocks the repository for security reasons and stops the update procedure.
As a result, the PrivacyIDEA Galera deployment cannot install or update the required MariaDB/Galera packages.

Problem Analysis:
The DigitalOcean mirror nyc2.mirrors.digitalocean.com no longer serves a valid Release file:
The repository 'http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.11/ubuntu jammy Release' does not have a Release file.

Fix:
mariadb_debian_repo: >
deb [arch=amd64,arm64,ppc64el]
[https://mirror.mariadb.org/repo/{{](https://mirror.mariadb.org/repo/%7B%7B) mariadb_version }}/{{ ansible_distribution|lower }}
{{ ansible_distribution_release|lower }} main
mariadb_debian_repo_pin: "mirror.mariadb.org"