### PR TITLE
Fix typo in redhat.yml for find the handler

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -63,7 +63,7 @@
     path: "/etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf"
     state: "absent"
   become: true
-  notify: reload systemd daemon
+  notify: Reload systemd daemon
 
 - name: redhat | ensuring mariadb mysql is enabled on boot
   ansible.builtin.service:


### PR DESCRIPTION
## Description
If u run the role the handler was not found because the typo cause not to the correct handler to reload systemd

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
